### PR TITLE
Diff-based email group sync (faster, batched, fewer rate limits)

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -2,8 +2,8 @@
 import os
 import sys
 
-if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ultimate.settings')
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ultimate.settings")
 
     from django.core.management import execute_from_command_line
 

--- a/src/requirements/prod.txt
+++ b/src/requirements/prod.txt
@@ -3,7 +3,6 @@
 # include common requirements
 -r common.txt
 
-
 bugsnag==4.3.0
 gevent==22.10.2
 greenlet==2.0.1

--- a/src/ultimate/leagues/admin.py
+++ b/src/ultimate/leagues/admin.py
@@ -170,11 +170,10 @@ class LeagueAdmin(admin.ModelAdmin):
         "year",
         "season",
         "night",
-        "display_format",
+        "gender",
         "type",
-        "max_players",
-        "display_fields",
-        "display_state",
+        "state_short",
+        "field_names",
     )
     list_display_links = ("id",)
     list_filter = (
@@ -197,32 +196,11 @@ class LeagueAdmin(admin.ModelAdmin):
         "gender",
     ]
 
-    def display_format(self, obj):
-        if obj.level != League.LEAGUE_LEVEL_RECREATIONAL:
-            return "{} - {}".format(
-                dict(League.LEAGUE_GENDER_CHOICES).get(obj.gender, "Unknown"),
-                dict(League.LEAGUE_LEVEL_CHOICES).get(obj.level, "Unknown"),
-            )
-        return "{}".format(
-            dict(League.LEAGUE_GENDER_CHOICES).get(obj.gender, "Unknown")
-        )
+    def state_short(self, obj):
+        return "{}".format(obj.display_state.split(" ").pop(0))
 
-    display_format.admin_order_field = "state"
-    display_format.short_description = "Format"
-
-    def display_state(self, obj):
-        return "{}".format(obj.state.title())
-
-    display_state.admin_order_field = "state"
-    display_state.short_description = "State"
-
-    def display_fields(self, obj):
-        return "{}".format(
-            "\n".join(obj.fields.all().order_by("name").values_list("name", flat=True))
-        )
-
-    display_fields.admin_order_field = "fields"
-    display_fields.short_description = "Fields"
+    def field_names(self, obj):
+        return "<br>".join([field.name for field in obj.fields.all()])
 
 
 def mark_flagged(modeladmin, request, queryset):

--- a/src/ultimate/leagues/management/commands/import_email_group.py
+++ b/src/ultimate/leagues/management/commands/import_email_group.py
@@ -124,324 +124,323 @@ class Command(BaseCommand):
         group_address = options.get("group_address", None)
         force = options.get("force", None)
 
-        success_count = 0
-
         if not group_address and (email_address or file_path):
             raise CommandError(
                 "group address (-g) is required with email (-e) or file (-f)"
             )
 
         if email_address:
-            self.stdout.write(
-                self.style.MIGRATE_HEADING("Adding email address to group:")
-            )
-            self.stdout.write("Adding {} to {}...".format(email_address, group_address))
-
-            success_count = add_to_group(
-                group_email_address=group_address, email_address=email_address
-            )
-
-            if success_count == 1:
-                self.stdout.write(self.style.SUCCESS("DONE"))
-                self.stdout.write(
-                    "Added {} to {}...".format(email_address, group_address)
-                )
-            else:
-                self.stdout.write(self.style.ERROR(" HMMM..."))
-                self.stdout.write(self.style.ERROR("No email addresses added..."))
-
+            self._handle_email(email_address, group_address)
         elif file_path:
-            self.stdout.write(self.style.MIGRATE_HEADING("Adding file to group:"))
-            self.stdout.write("Adding file to {}...".format(group_address), ending="")
-
-            success_count = add_to_group(
-                group_email_address=group_address, file_path=file_path
-            )
-
-            if success_count > 0:
-                self.stdout.write(self.style.SUCCESS("DONE"))
-            else:
-                self.stdout.write(self.style.ERROR(" HMMM..."))
-                self.stdout.write(self.style.ERROR("No email addresses added..."))
-
+            self._handle_file(file_path, group_address)
         elif team_id:
-            self.stdout.write(
-                self.style.MIGRATE_HEADING("Syncing team email addresses:")
-            )
-
-            from ultimate.leagues.models import Team
-
-            try:
-                team = Team.objects.get(id=team_id)
-
-                result, group_address = team.sync_email_group(force)
-                self._report_sync_result(result, group_address)
-
-            except Team.DoesNotExist:
-                self.stdout.write(self.style.ERROR("No team found with that id"))
-
+            self._handle_team(team_id, force)
         elif league_id:
-            self.stdout.write(
-                self.style.MIGRATE_HEADING("Syncing division email addresses:")
-            )
+            self._handle_league(league_id, force)
+        elif season_slug and year:
+            self._handle_season(season_slug, year, pickup, force)
 
-            from ultimate.leagues.models import League
+    def _handle_email(self, email_address, group_address):
+        self.stdout.write(self.style.MIGRATE_HEADING("Adding email address to group:"))
+        self.stdout.write("Adding {} to {}...".format(email_address, group_address))
 
-            try:
-                league = League.objects.get(id=league_id)
+        success_count = add_to_group(
+            group_email_address=group_address, email_address=email_address
+        )
 
-                (
-                    all_result,
-                    group_address,
-                    captains_result,
-                    captains_group_address,
-                ) = league.sync_email_groups(force)
+        if success_count == 1:
+            self.stdout.write(self.style.SUCCESS("DONE"))
+            self.stdout.write("Added {} to {}...".format(email_address, group_address))
+        else:
+            self.stdout.write(self.style.ERROR(" HMMM..."))
+            self.stdout.write(self.style.ERROR("No email addresses added..."))
 
-                self._report_sync_result(all_result, group_address)
-                self._report_sync_result(captains_result, captains_group_address)
+    def _handle_file(self, file_path, group_address):
+        self.stdout.write(self.style.MIGRATE_HEADING("Adding file to group:"))
+        self.stdout.write("Adding file to {}...".format(group_address), ending="")
 
-            except League.DoesNotExist:
+        success_count = add_to_group(
+            group_email_address=group_address, file_path=file_path
+        )
+
+        if success_count > 0:
+            self.stdout.write(self.style.SUCCESS("DONE"))
+        else:
+            self.stdout.write(self.style.ERROR(" HMMM..."))
+            self.stdout.write(self.style.ERROR("No email addresses added..."))
+
+    def _handle_team(self, team_id, force):
+        self.stdout.write(self.style.MIGRATE_HEADING("Syncing team email addresses:"))
+
+        from ultimate.leagues.models import Team
+
+        try:
+            team = Team.objects.get(id=team_id)
+
+            result, group_address = team.sync_email_group(force)
+            self._report_sync_result(result, group_address)
+
+        except Team.DoesNotExist:
+            self.stdout.write(self.style.ERROR("No team found with that id"))
+
+    def _handle_league(self, league_id, force):
+        self.stdout.write(
+            self.style.MIGRATE_HEADING("Syncing division email addresses:")
+        )
+
+        from ultimate.leagues.models import League
+
+        try:
+            league = League.objects.get(id=league_id)
+
+            (
+                all_result,
+                group_address,
+                captains_result,
+                captains_group_address,
+            ) = league.sync_email_groups(force)
+
+            self._report_sync_result(all_result, group_address)
+            self._report_sync_result(captains_result, captains_group_address)
+
+        except League.DoesNotExist:
+            self.stdout.write(self.style.ERROR("No league division found with that id"))
+
+    def _handle_season(self, season_slug, year, pickup, force):
+        from ultimate.leagues.models import Season, TeamMember
+
+        try:
+            season = Season.objects.get(slug=season_slug)
+
+            from ultimate.utils.google_api import GoogleAppsApi
+
+            api = GoogleAppsApi()
+
+            if pickup:
                 self.stdout.write(
-                    self.style.ERROR("No league division found with that id")
+                    self.style.MIGRATE_HEADING(
+                        "Syncing pickup list for {} {}:".format(season_slug, year[-2:])
+                    )
                 )
 
-        elif season_slug and year:
-            from ultimate.leagues.models import Season, TeamMember
+                pickup_team_members = []
+                previous_year = str(int(year) - 1)
 
-            try:
-                season = Season.objects.get(slug=season_slug)
-
-                from ultimate.utils.google_api import GoogleAppsApi
-
-                api = GoogleAppsApi()
-
-                if pickup:
-                    self.stdout.write(
-                        self.style.MIGRATE_HEADING(
-                            "Syncing pickup list for {} {}:".format(
-                                season_slug, year[-2:]
-                            )
-                        )
-                    )
-
-                    pickup_team_members = []
-                    previous_year = str(int(year) - 1)
-
-                    if season_slug == "winter":
-                        pickup_team_members = (
-                            TeamMember.objects.filter(
+                if season_slug == "winter":
+                    pickup_team_members = (
+                        TeamMember.objects.filter(
+                            Q(
                                 Q(
-                                    Q(
-                                        Q(team__league__season__slug="fall")
-                                        & Q(team__league__year=previous_year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="late-fall")
-                                        & Q(team__league__year=previous_year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="winter")
-                                        & Q(team__league__year=year)
-                                    )
+                                    Q(team__league__season__slug="fall")
+                                    & Q(team__league__year=previous_year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="late-fall")
+                                    & Q(team__league__year=previous_year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="winter")
+                                    & Q(team__league__year=year)
                                 )
                             )
-                            .values()
-                            .annotate(email=Lower("user__email"))
-                            .order_by("user__email")
                         )
-                    elif season_slug == "spring":
-                        pickup_team_members = (
-                            TeamMember.objects.filter(
+                        .values()
+                        .annotate(email=Lower("user__email"))
+                        .order_by("user__email")
+                    )
+                elif season_slug == "spring":
+                    pickup_team_members = (
+                        TeamMember.objects.filter(
+                            Q(
                                 Q(
-                                    Q(
-                                        Q(team__league__season__slug="late-fall")
-                                        & Q(team__league__year=previous_year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="winter")
-                                        & Q(team__league__year=year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="spring")
-                                        & Q(team__league__year=year)
-                                    )
+                                    Q(team__league__season__slug="late-fall")
+                                    & Q(team__league__year=previous_year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="winter")
+                                    & Q(team__league__year=year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="spring")
+                                    & Q(team__league__year=year)
                                 )
                             )
-                            .values()
-                            .annotate(email=Lower("user__email"))
-                            .order_by("user__email")
                         )
-                    elif season_slug == "summer":
-                        pickup_team_members = (
-                            TeamMember.objects.filter(
+                        .values()
+                        .annotate(email=Lower("user__email"))
+                        .order_by("user__email")
+                    )
+                elif season_slug == "summer":
+                    pickup_team_members = (
+                        TeamMember.objects.filter(
+                            Q(
                                 Q(
-                                    Q(
-                                        Q(team__league__season__slug="winter")
-                                        & Q(team__league__year=year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="spring")
-                                        & Q(team__league__year=year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="summer")
-                                        & Q(team__league__year=year)
-                                    )
+                                    Q(team__league__season__slug="winter")
+                                    & Q(team__league__year=year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="spring")
+                                    & Q(team__league__year=year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="summer")
+                                    & Q(team__league__year=year)
                                 )
                             )
-                            .values()
-                            .annotate(email=Lower("user__email"))
-                            .order_by("user__email")
                         )
-                    elif season_slug == "fall":
-                        pickup_team_members = (
-                            TeamMember.objects.filter(
+                        .values()
+                        .annotate(email=Lower("user__email"))
+                        .order_by("user__email")
+                    )
+                elif season_slug == "fall":
+                    pickup_team_members = (
+                        TeamMember.objects.filter(
+                            Q(
                                 Q(
-                                    Q(
-                                        Q(team__league__season__slug="spring")
-                                        & Q(team__league__year=year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="summer")
-                                        & Q(team__league__year=year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="fall")
-                                        & Q(team__league__year=year)
-                                    )
+                                    Q(team__league__season__slug="spring")
+                                    & Q(team__league__year=year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="summer")
+                                    & Q(team__league__year=year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="fall")
+                                    & Q(team__league__year=year)
                                 )
                             )
-                            .values()
-                            .annotate(email=Lower("user__email"))
-                            .order_by("user__email")
                         )
-                    elif season_slug == "late-fall":
-                        # do not include late fall since there is only one division
-                        pickup_team_members = (
-                            TeamMember.objects.filter(
+                        .values()
+                        .annotate(email=Lower("user__email"))
+                        .order_by("user__email")
+                    )
+                elif season_slug == "late-fall":
+                    # do not include late fall since there is only one division
+                    pickup_team_members = (
+                        TeamMember.objects.filter(
+                            Q(
                                 Q(
-                                    Q(
-                                        Q(team__league__season__slug="summer")
-                                        & Q(team__league__year=year)
-                                    )
-                                    | Q(
-                                        Q(team__league__season__slug="fall")
-                                        & Q(team__league__year=year)
-                                    )
+                                    Q(team__league__season__slug="summer")
+                                    & Q(team__league__year=year)
+                                )
+                                | Q(
+                                    Q(team__league__season__slug="fall")
+                                    & Q(team__league__year=year)
                                 )
                             )
-                            .values()
-                            .annotate(email=Lower("user__email"))
-                            .order_by("user__email")
                         )
+                        .values()
+                        .annotate(email=Lower("user__email"))
+                        .order_by("user__email")
+                    )
 
-                    pickup_email_addresses = {
-                        ptm["email"] for ptm in pickup_team_members
-                    }
+                pickup_email_addresses = {
+                    ptm["email"] for ptm in pickup_team_members
+                }
 
-                    pickup_group_address = (
-                        "{}{}-pickups@lists.annarborultimate.org".format(
-                            season.slug, year[-2:]
+                pickup_group_address = (
+                    "{}{}-pickups@lists.annarborultimate.org".format(
+                        season.slug, year[-2:]
+                    )
+                )
+                pickup_group_name = "{} {} Pickups".format(season.name, year)
+                pickup_group_id = api.prepare_group_for_sync(
+                    group_name=pickup_group_name,
+                    group_email_address=pickup_group_address,
+                    force=force,
+                )
+
+                pickup_result = api.sync_group_members(
+                    pickup_email_addresses,
+                    group_id=pickup_group_id,
+                    group_email_address=pickup_group_address,
+                )
+
+                self._report_sync_result(pickup_result, pickup_group_address)
+
+            else:
+                self.stdout.write(
+                    self.style.MIGRATE_HEADING(
+                        "Syncing season list for {} {}:".format(
+                            season_slug, year[-2:]
                         )
                     )
-                    pickup_group_name = "{} {} Pickups".format(season.name, year)
-                    pickup_group_id = api.prepare_group_for_sync(
-                        group_name=pickup_group_name,
-                        group_email_address=pickup_group_address,
-                        force=force,
-                    )
+                )
 
-                    pickup_result = api.sync_group_members(
-                        pickup_email_addresses,
-                        group_id=pickup_group_id,
-                        group_email_address=pickup_group_address,
-                    )
+                # # ALL
 
-                    self._report_sync_result(pickup_result, pickup_group_address)
+                # all_group_address = '{}{}@lists.annarborultimate.org'.format(season.slug, year[-2:])
+                # all_group_name = '{} {}'.format(season.name, year)
+                # all_group_id = api.prepare_group_for_sync(
+                #     group_name=all_group_name,
+                #     group_email_address=all_group_address,
+                #     force=force)
 
-                else:
-                    self.stdout.write(
-                        self.style.MIGRATE_HEADING(
-                            "Syncing season list for {} {}:".format(
-                                season_slug, year[-2:]
-                            )
-                        )
-                    )
+                # all_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year)
+                # all_target_count = all_team_members.count()
+                # all_success_count = 0
+                # for team_member in all_team_members:
+                #     all_success_count += add_to_group(
+                #         group_email_address=all_group_address,
+                #         group_id=all_group_id,
+                #         email_address=team_member.user.email)
 
-                    # # ALL
+                # # MEN
 
-                    # all_group_address = '{}{}@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                    # all_group_name = '{} {}'.format(season.name, year)
-                    # all_group_id = api.prepare_group_for_sync(
-                    #     group_name=all_group_name,
-                    #     group_email_address=all_group_address,
-                    #     force=force)
+                # men_group_address = '{}{}-men@lists.annarborultimate.org'.format(season.slug, year[-2:])
+                # men_group_name = '{} {} Men'.format(season.name, year)
+                # men_group_id = api.prepare_group_for_sync(
+                #     group_name=men_group_name,
+                #     group_email_address=men_group_address,
+                #     force=force)
 
-                    # all_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year)
-                    # all_target_count = all_team_members.count()
-                    # all_success_count = 0
-                    # for team_member in all_team_members:
-                    #     all_success_count += add_to_group(
-                    #         group_email_address=all_group_address,
-                    #         group_id=all_group_id,
-                    #         email_address=team_member.user.email)
+                # men_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='M')
+                # men_target_count = men_team_members.count()
+                # men_success_count = 0
+                # for team_member in men_team_members:
+                #     men_success_count += add_to_group(
+                #         group_email_address=men_group_address,
+                #         group_id=men_group_id,
+                #         email_address=team_member.user.email)
 
-                    # # MEN
+                # # WOMEN
 
-                    # men_group_address = '{}{}-men@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                    # men_group_name = '{} {} Men'.format(season.name, year)
-                    # men_group_id = api.prepare_group_for_sync(
-                    #     group_name=men_group_name,
-                    #     group_email_address=men_group_address,
-                    #     force=force)
+                # women_group_address = '{}{}-women@lists.annarborultimate.org'.format(season.slug, year[-2:])
+                # women_group_name = '{} {} Women'.format(season.name, year)
+                # women_group_id = api.prepare_group_for_sync(
+                #     group_name=women_group_name,
+                #     group_email_address=women_group_address,
+                #     force=force)
 
-                    # men_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='M')
-                    # men_target_count = men_team_members.count()
-                    # men_success_count = 0
-                    # for team_member in men_team_members:
-                    #     men_success_count += add_to_group(
-                    #         group_email_address=men_group_address,
-                    #         group_id=men_group_id,
-                    #         email_address=team_member.user.email)
+                # women_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='F')
+                # women_target_count = women_team_members.count()
+                # women_success_count = 0
+                # for team_member in women_team_members:
+                #     women_success_count += add_to_group(
+                #         group_email_address=women_group_address,
+                #         group_id=women_group_id,
+                #         email_address=team_member.user.email)
 
-                    # # WOMEN
+                # if all_success_count == all_team_members.count():
+                #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
+                #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
+                # else:
+                #     self.stdout.write(self.style.ERROR('HMMM...'))
+                #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
 
-                    # women_group_address = '{}{}-women@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                    # women_group_name = '{} {} Women'.format(season.name, year)
-                    # women_group_id = api.prepare_group_for_sync(
-                    #     group_name=women_group_name,
-                    #     group_email_address=women_group_address,
-                    #     force=force)
+                # if men_success_count == men_team_members.count():
+                #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
+                #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
+                # else:
+                #     self.stdout.write(self.style.ERROR('HMMM...'))
+                #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
 
-                    # women_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='F')
-                    # women_target_count = women_team_members.count()
-                    # women_success_count = 0
-                    # for team_member in women_team_members:
-                    #     women_success_count += add_to_group(
-                    #         group_email_address=women_group_address,
-                    #         group_id=women_group_id,
-                    #         email_address=team_member.user.email)
+                # if women_success_count == women_team_members.count():
+                #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
+                #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
+                # else:
+                #     self.stdout.write(self.style.ERROR('HMMM...'))
+                #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
 
-                    # if all_success_count == all_team_members.count():
-                    #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                    #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
-                    # else:
-                    #     self.stdout.write(self.style.ERROR('HMMM...'))
-                    #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
-
-                    # if men_success_count == men_team_members.count():
-                    #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                    #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
-                    # else:
-                    #     self.stdout.write(self.style.ERROR('HMMM...'))
-                    #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
-
-                    # if women_success_count == women_team_members.count():
-                    #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                    #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
-                    # else:
-                    #     self.stdout.write(self.style.ERROR('HMMM...'))
-                    #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
-
-            except Season.DoesNotExist:
-                self.stdout.write(self.style.ERROR("No season found with that slug"))
+        except Season.DoesNotExist:
+            self.stdout.write(self.style.ERROR("No season found with that slug"))

--- a/src/ultimate/leagues/management/commands/import_email_group.py
+++ b/src/ultimate/leagues/management/commands/import_email_group.py
@@ -130,20 +130,26 @@ class Command(BaseCommand):
             )
 
     def handle(self, *args, **options):
-        email_address = options.get("email", None)
-        file_path = options.get("file", None)
-        team_id = options.get("team", None)
-        league_id = options.get("league", None)
-        season_slug = options.get("season", None)
-        year = options.get("year", None)
-        pickup = options.get("pickup", None)
-        group_address = options.get("group_address", None)
-        force = options.get("force", None)
+        email_address = options["email"]
+        file_path = options["file"]
+        team_id = options["team"]
+        league_id = options["league"]
+        season_slug = options["season"]
+        year = options["year"]
+        pickup = options["pickup"]
+        group_address = options["group_address"]
+        force = options["force"]
 
         if not group_address and (email_address or file_path):
             raise CommandError(
                 "group address (-g) is required with email (-e) or file (-f)"
             )
+
+        if (season_slug and not year) or (year and not season_slug):
+            raise CommandError("season (-s) and year (-y) must be given together")
+
+        if year and not year.isdigit():
+            raise CommandError("year (-y) must be a numeric year, e.g. 2019")
 
         if email_address:
             self._handle_email(email_address, group_address)
@@ -291,88 +297,10 @@ class Command(BaseCommand):
                 self._report_sync_result(pickup_result, pickup_group_address)
 
             else:
-                self.stdout.write(
-                    self.style.MIGRATE_HEADING(
-                        "Syncing season list for {} {}:".format(
-                            season_slug, year[-2:]
-                        )
-                    )
+                raise CommandError(
+                    "Season list sync (without -p) is not implemented; "
+                    "use -p to sync the pickup list."
                 )
-
-                # # ALL
-
-                # all_group_address = '{}{}@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                # all_group_name = '{} {}'.format(season.name, year)
-                # all_group_id = api.prepare_group_for_sync(
-                #     group_name=all_group_name,
-                #     group_email_address=all_group_address,
-                #     force=force)
-
-                # all_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year)
-                # all_target_count = all_team_members.count()
-                # all_success_count = 0
-                # for team_member in all_team_members:
-                #     all_success_count += add_to_group(
-                #         group_email_address=all_group_address,
-                #         group_id=all_group_id,
-                #         email_address=team_member.user.email)
-
-                # # MEN
-
-                # men_group_address = '{}{}-men@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                # men_group_name = '{} {} Men'.format(season.name, year)
-                # men_group_id = api.prepare_group_for_sync(
-                #     group_name=men_group_name,
-                #     group_email_address=men_group_address,
-                #     force=force)
-
-                # men_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='M')
-                # men_target_count = men_team_members.count()
-                # men_success_count = 0
-                # for team_member in men_team_members:
-                #     men_success_count += add_to_group(
-                #         group_email_address=men_group_address,
-                #         group_id=men_group_id,
-                #         email_address=team_member.user.email)
-
-                # # WOMEN
-
-                # women_group_address = '{}{}-women@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                # women_group_name = '{} {} Women'.format(season.name, year)
-                # women_group_id = api.prepare_group_for_sync(
-                #     group_name=women_group_name,
-                #     group_email_address=women_group_address,
-                #     force=force)
-
-                # women_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='F')
-                # women_target_count = women_team_members.count()
-                # women_success_count = 0
-                # for team_member in women_team_members:
-                #     women_success_count += add_to_group(
-                #         group_email_address=women_group_address,
-                #         group_id=women_group_id,
-                #         email_address=team_member.user.email)
-
-                # if all_success_count == all_team_members.count():
-                #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
-                # else:
-                #     self.stdout.write(self.style.ERROR('HMMM...'))
-                #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
-
-                # if men_success_count == men_team_members.count():
-                #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
-                # else:
-                #     self.stdout.write(self.style.ERROR('HMMM...'))
-                #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
-
-                # if women_success_count == women_team_members.count():
-                #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
-                # else:
-                #     self.stdout.write(self.style.ERROR('HMMM...'))
-                #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
 
         except Season.DoesNotExist:
             self.stdout.write(self.style.ERROR("No season found with that slug"))

--- a/src/ultimate/leagues/management/commands/import_email_group.py
+++ b/src/ultimate/leagues/management/commands/import_email_group.py
@@ -76,6 +76,43 @@ class Command(BaseCommand):
             help="force group create or find (only for team)",
         )
 
+    def _report_sync_result(self, result, group_address):
+        """Print the outcome of a diff-based group sync (a GroupSyncResult)."""
+        failed = result.failed_add + result.failed_remove
+
+        if not failed:
+            self.stdout.write(self.style.SUCCESS("SUCCESS"))
+            style = self.style.SUCCESS
+        else:
+            self.stdout.write(self.style.ERROR("HMMM..."))
+            style = self.style.ERROR
+
+        self.stdout.write(
+            style(
+                "Synced {}: {} added, {} removed, {} total members".format(
+                    group_address,
+                    len(result.added),
+                    len(result.removed),
+                    result.target,
+                )
+            )
+        )
+
+        if result.failed_add:
+            self.stdout.write(
+                self.style.ERROR(
+                    "Could not add: {}".format(", ".join(sorted(result.failed_add)))
+                )
+            )
+        if result.failed_remove:
+            self.stdout.write(
+                self.style.ERROR(
+                    "Could not remove: {}".format(
+                        ", ".join(sorted(result.failed_remove))
+                    )
+                )
+            )
+
     def handle(self, *args, **options):
         email_address = options.get("email", None)
         file_path = options.get("file", None)
@@ -137,30 +174,8 @@ class Command(BaseCommand):
             try:
                 team = Team.objects.get(id=team_id)
 
-                success_count, group_address = team.sync_email_group(force)
-                target_count = team.size
-
-                if success_count == target_count:
-                    self.stdout.write(self.style.SUCCESS("SUCCESS"))
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            "Added {} of {} email addresses to {}".format(
-                                success_count, target_count, group_address
-                            )
-                        )
-                    )
-                elif success_count > 0:
-                    self.stdout.write(self.style.ERROR("HMMM..."))
-                    self.stdout.write(
-                        self.style.ERROR(
-                            "Added {} of {} email addresses to {}".format(
-                                success_count, target_count, group_address
-                            )
-                        )
-                    )
-                else:
-                    self.stdout.write(self.style.ERROR("HMMM..."))
-                    self.stdout.write(self.style.ERROR("No email addresses added..."))
+                result, group_address = team.sync_email_group(force)
+                self._report_sync_result(result, group_address)
 
             except Team.DoesNotExist:
                 self.stdout.write(self.style.ERROR("No team found with that id"))
@@ -176,57 +191,14 @@ class Command(BaseCommand):
                 league = League.objects.get(id=league_id)
 
                 (
-                    all_success_count,
+                    all_result,
                     group_address,
-                    captains_success_count,
+                    captains_result,
                     captains_group_address,
                 ) = league.sync_email_groups(force)
 
-                all_target_count = league.get_player_count()
-                captains_target_count = league.get_captain_count()
-
-                if (
-                    all_success_count == all_target_count
-                    and captains_success_count == captains_target_count
-                ):
-                    self.stdout.write(self.style.SUCCESS("SUCCESS"))
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            "Added {} of {} email addresses to {}".format(
-                                all_success_count, all_target_count, group_address
-                            )
-                        )
-                    )
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            "Added {} of {} email addresses to {}".format(
-                                captains_success_count,
-                                captains_target_count,
-                                captains_group_address,
-                            )
-                        )
-                    )
-                elif all_success_count > 0 or captains_success_count > 0:
-                    self.stdout.write(self.style.ERROR("HMMM..."))
-                    self.stdout.write(
-                        self.style.ERROR(
-                            "Added {} of {} email addresses to {}".format(
-                                all_success_count, all_target_count, group_address
-                            )
-                        )
-                    )
-                    self.stdout.write(
-                        self.style.ERROR(
-                            "Added {} of {} email addresses to {}".format(
-                                captains_success_count,
-                                captains_target_count,
-                                captains_group_address,
-                            )
-                        )
-                    )
-                else:
-                    self.stdout.write(self.style.ERROR("HMMM..."))
-                    self.stdout.write(self.style.ERROR("No email addresses added..."))
+                self._report_sync_result(all_result, group_address)
+                self._report_sync_result(captains_result, captains_group_address)
 
             except League.DoesNotExist:
                 self.stdout.write(

--- a/src/ultimate/leagues/management/commands/import_email_group.py
+++ b/src/ultimate/leagues/management/commands/import_email_group.py
@@ -1,131 +1,139 @@
-import httplib2
-import sys
-
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
 from django.db.models.functions import Lower
 
-from googleapiclient.discovery import build
-from oauth2client.service_account import ServiceAccountCredentials
 
 from ultimate.utils.email_groups import add_to_group
 
 
 class Command(BaseCommand):
-    help = 'Add members to an email group from an email address, file, or team id'
+    help = "Add members to an email group from an email address, file, or team id"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '-e',
-            dest='email',
-            default='',
-            help='Add single email address',
+            "-e",
+            dest="email",
+            default="",
+            help="Add single email address",
         )
 
         parser.add_argument(
-            '-f',
-            dest='file',
-            default='',
-            help='Import from a file',
+            "-f",
+            dest="file",
+            default="",
+            help="Import from a file",
         )
 
         parser.add_argument(
-            '-t',
+            "-t",
             type=int,
-            dest='team',
+            dest="team",
             default=0,
-            help='Sync a team (team id)',
+            help="Sync a team (team id)",
         )
 
         parser.add_argument(
-            '-l',
-            default='',
-            dest='league',
-            help='Sync a division (league id)',
+            "-l",
+            default="",
+            dest="league",
+            help="Sync a division (league id)",
         )
 
         parser.add_argument(
-            '-s',
-            default='',
-            dest='season',
+            "-s",
+            default="",
+            dest="season",
             help='Sync a league (season + year), "winter", "spring", "summer", "fall", "late-fall"',
         )
 
         parser.add_argument(
-            '-y',
-            default='',
-            dest='year',
-            help='Sync a league (season + year), e.g. 2019',
+            "-y",
+            default="",
+            dest="year",
+            help="Sync a league (season + year), e.g. 2019",
         )
 
         parser.add_argument(
-            '-p',
-            action='store_true',
+            "-p",
+            action="store_true",
             default=False,
-            dest='pickup',
-            help='Sync a league pickup list',
+            dest="pickup",
+            help="Sync a league pickup list",
         )
 
         parser.add_argument(
-            '-g',
-            default='',
-            dest='group_address',
-            help='Group Address (required for email and file)',
+            "-g",
+            default="",
+            dest="group_address",
+            help="Group Address (required for email and file)",
         )
 
         parser.add_argument(
-            '--force',
-            action='store_true',
+            "--force",
+            action="store_true",
             default=False,
-            dest='force',
-            help='force group create or find (only for team)',
+            dest="force",
+            help="force group create or find (only for team)",
         )
 
     def handle(self, *args, **options):
-        email_address = options.get('email', None)
-        file_path = options.get('file', None)
-        team_id = options.get('team', None)
-        league_id = options.get('league', None)
-        season_slug = options.get('season', None)
-        year = options.get('year', None)
-        pickup = options.get('pickup', None)
-        group_address = options.get('group_address', None)
-        force = options.get('force', None)
+        email_address = options.get("email", None)
+        file_path = options.get("file", None)
+        team_id = options.get("team", None)
+        league_id = options.get("league", None)
+        season_slug = options.get("season", None)
+        year = options.get("year", None)
+        pickup = options.get("pickup", None)
+        group_address = options.get("group_address", None)
+        force = options.get("force", None)
 
         success_count = 0
 
         if not group_address and (email_address or file_path):
-            raise CommandError('group address (-g) is required with email (-e) or file (-f)')
+            raise CommandError(
+                "group address (-g) is required with email (-e) or file (-f)"
+            )
 
         if email_address:
-            self.stdout.write(self.style.MIGRATE_HEADING('Adding email address to group:'))
-            self.stdout.write('Adding {} to {}...'.format(email_address, group_address))
+            self.stdout.write(
+                self.style.MIGRATE_HEADING("Adding email address to group:")
+            )
+            self.stdout.write("Adding {} to {}...".format(email_address, group_address))
 
-            success_count = add_to_group(group_email_address=group_address, email_address=email_address)
+            success_count = add_to_group(
+                group_email_address=group_address, email_address=email_address
+            )
 
             if success_count == 1:
-                self.stdout.write(self.style.SUCCESS('DONE'))
-                self.stdout.write('Added {} to {}...'.format(email_address, group_address))
+                self.stdout.write(self.style.SUCCESS("DONE"))
+                self.stdout.write(
+                    "Added {} to {}...".format(email_address, group_address)
+                )
             else:
-                self.stdout.write(self.style.ERROR(' HMMM...'))
-                self.stdout.write(self.style.ERROR('No email addresses added...'))
+                self.stdout.write(self.style.ERROR(" HMMM..."))
+                self.stdout.write(self.style.ERROR("No email addresses added..."))
 
         elif file_path:
-            self.stdout.write(self.style.MIGRATE_HEADING('Adding file to group:'))
-            self.stdout.write('Adding file to {}...'.format(group_address), ending='')
+            self.stdout.write(self.style.MIGRATE_HEADING("Adding file to group:"))
+            self.stdout.write("Adding file to {}...".format(group_address), ending="")
 
-            success_count = add_to_group(group_email_address=group_address, file_path=file_path)
+            success_count = add_to_group(
+                group_email_address=group_address, file_path=file_path
+            )
 
             if success_count > 0:
-                self.stdout.write(self.style.SUCCESS('DONE'))
+                self.stdout.write(self.style.SUCCESS("DONE"))
             else:
-                self.stdout.write(self.style.ERROR(' HMMM...'))
-                self.stdout.write(self.style.ERROR('No email addresses added...'))
+                self.stdout.write(self.style.ERROR(" HMMM..."))
+                self.stdout.write(self.style.ERROR("No email addresses added..."))
 
         elif team_id:
-            self.stdout.write(self.style.MIGRATE_HEADING('Syncing team email addresses:'))
+            self.stdout.write(
+                self.style.MIGRATE_HEADING("Syncing team email addresses:")
+            )
 
             from ultimate.leagues.models import Team
+
             try:
                 team = Team.objects.get(id=team_id)
 
@@ -133,90 +141,243 @@ class Command(BaseCommand):
                 target_count = team.size
 
                 if success_count == target_count:
-                    self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                    self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(success_count, target_count, group_address)))
+                    self.stdout.write(self.style.SUCCESS("SUCCESS"))
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "Added {} of {} email addresses to {}".format(
+                                success_count, target_count, group_address
+                            )
+                        )
+                    )
                 elif success_count > 0:
-                    self.stdout.write(self.style.ERROR('HMMM...'))
-                    self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(success_count, target_count, group_address)))
+                    self.stdout.write(self.style.ERROR("HMMM..."))
+                    self.stdout.write(
+                        self.style.ERROR(
+                            "Added {} of {} email addresses to {}".format(
+                                success_count, target_count, group_address
+                            )
+                        )
+                    )
                 else:
-                    self.stdout.write(self.style.ERROR('HMMM...'))
-                    self.stdout.write(self.style.ERROR('No email addresses added...'))
+                    self.stdout.write(self.style.ERROR("HMMM..."))
+                    self.stdout.write(self.style.ERROR("No email addresses added..."))
 
             except Team.DoesNotExist:
-                self.stdout.write(self.style.ERROR('No team found with that id'))
+                self.stdout.write(self.style.ERROR("No team found with that id"))
 
         elif league_id:
-            self.stdout.write(self.style.MIGRATE_HEADING('Syncing division email addresses:'))
+            self.stdout.write(
+                self.style.MIGRATE_HEADING("Syncing division email addresses:")
+            )
 
             from ultimate.leagues.models import League
+
             try:
                 league = League.objects.get(id=league_id)
 
-                all_success_count, group_address, captains_success_count, captains_group_address = \
-                    league.sync_email_groups(force)
+                (
+                    all_success_count,
+                    group_address,
+                    captains_success_count,
+                    captains_group_address,
+                ) = league.sync_email_groups(force)
 
                 all_target_count = league.get_player_count()
                 captains_target_count = league.get_captain_count()
 
-                if all_success_count == all_target_count and captains_success_count == captains_target_count:
-                    self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                    self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, group_address)))
-                    self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(captains_success_count, captains_target_count, captains_group_address)))
+                if (
+                    all_success_count == all_target_count
+                    and captains_success_count == captains_target_count
+                ):
+                    self.stdout.write(self.style.SUCCESS("SUCCESS"))
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "Added {} of {} email addresses to {}".format(
+                                all_success_count, all_target_count, group_address
+                            )
+                        )
+                    )
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "Added {} of {} email addresses to {}".format(
+                                captains_success_count,
+                                captains_target_count,
+                                captains_group_address,
+                            )
+                        )
+                    )
                 elif all_success_count > 0 or captains_success_count > 0:
-                    self.stdout.write(self.style.ERROR('HMMM...'))
-                    self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, group_address)))
-                    self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(captains_success_count, captains_target_count, captains_group_address)))
+                    self.stdout.write(self.style.ERROR("HMMM..."))
+                    self.stdout.write(
+                        self.style.ERROR(
+                            "Added {} of {} email addresses to {}".format(
+                                all_success_count, all_target_count, group_address
+                            )
+                        )
+                    )
+                    self.stdout.write(
+                        self.style.ERROR(
+                            "Added {} of {} email addresses to {}".format(
+                                captains_success_count,
+                                captains_target_count,
+                                captains_group_address,
+                            )
+                        )
+                    )
                 else:
-                    self.stdout.write(self.style.ERROR('HMMM...'))
-                    self.stdout.write(self.style.ERROR('No email addresses added...'))
+                    self.stdout.write(self.style.ERROR("HMMM..."))
+                    self.stdout.write(self.style.ERROR("No email addresses added..."))
 
             except League.DoesNotExist:
-                self.stdout.write(self.style.ERROR('No league division found with that id'))
+                self.stdout.write(
+                    self.style.ERROR("No league division found with that id")
+                )
 
         elif season_slug and year:
-
             from ultimate.leagues.models import Season, TeamMember
+
             try:
                 season = Season.objects.get(slug=season_slug)
 
                 from ultimate.utils.google_api import GoogleAppsApi
+
                 api = GoogleAppsApi()
 
                 if pickup:
-                    self.stdout.write(self.style.MIGRATE_HEADING('Syncing pickup list for {} {}:'.format(season_slug, year[-2:])))
+                    self.stdout.write(
+                        self.style.MIGRATE_HEADING(
+                            "Syncing pickup list for {} {}:".format(
+                                season_slug, year[-2:]
+                            )
+                        )
+                    )
 
                     pickup_team_members = []
                     previous_year = str(int(year) - 1)
 
-                    if season_slug == 'winter':
-                        pickup_team_members = TeamMember.objects.filter(Q(Q(Q(team__league__season__slug='fall') & Q(team__league__year=previous_year)) |
-                            Q(Q(team__league__season__slug='late-fall') & Q(team__league__year=previous_year)) |
-                            Q(Q(team__league__season__slug='winter') & Q(team__league__year=year)))).values().annotate(email=Lower('user__email')).order_by('user__email')
-                    elif season_slug == 'spring':
-                        pickup_team_members = TeamMember.objects.filter(Q(Q(Q(team__league__season__slug='late-fall') & Q(team__league__year=previous_year)) |
-                            Q(Q(team__league__season__slug='winter') & Q(team__league__year=year)) |
-                            Q(Q(team__league__season__slug='spring') & Q(team__league__year=year)))).values().annotate(email=Lower('user__email')).order_by('user__email')
-                    elif season_slug == 'summer':
-                        pickup_team_members = TeamMember.objects.filter(Q(Q(Q(team__league__season__slug='winter') & Q(team__league__year=year)) |
-                            Q(Q(team__league__season__slug='spring') & Q(team__league__year=year)) |
-                            Q(Q(team__league__season__slug='summer') & Q(team__league__year=year)))).values().annotate(email=Lower('user__email')).order_by('user__email')
-                    elif season_slug == 'fall':
-                        pickup_team_members = TeamMember.objects.filter(Q(Q(Q(team__league__season__slug='spring') & Q(team__league__year=year)) |
-                            Q(Q(team__league__season__slug='summer') & Q(team__league__year=year)) |
-                            Q(Q(team__league__season__slug='fall') & Q(team__league__year=year)))).values().annotate(email=Lower('user__email')).order_by('user__email')
-                    elif season_slug == 'late-fall':
+                    if season_slug == "winter":
+                        pickup_team_members = (
+                            TeamMember.objects.filter(
+                                Q(
+                                    Q(
+                                        Q(team__league__season__slug="fall")
+                                        & Q(team__league__year=previous_year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="late-fall")
+                                        & Q(team__league__year=previous_year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="winter")
+                                        & Q(team__league__year=year)
+                                    )
+                                )
+                            )
+                            .values()
+                            .annotate(email=Lower("user__email"))
+                            .order_by("user__email")
+                        )
+                    elif season_slug == "spring":
+                        pickup_team_members = (
+                            TeamMember.objects.filter(
+                                Q(
+                                    Q(
+                                        Q(team__league__season__slug="late-fall")
+                                        & Q(team__league__year=previous_year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="winter")
+                                        & Q(team__league__year=year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="spring")
+                                        & Q(team__league__year=year)
+                                    )
+                                )
+                            )
+                            .values()
+                            .annotate(email=Lower("user__email"))
+                            .order_by("user__email")
+                        )
+                    elif season_slug == "summer":
+                        pickup_team_members = (
+                            TeamMember.objects.filter(
+                                Q(
+                                    Q(
+                                        Q(team__league__season__slug="winter")
+                                        & Q(team__league__year=year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="spring")
+                                        & Q(team__league__year=year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="summer")
+                                        & Q(team__league__year=year)
+                                    )
+                                )
+                            )
+                            .values()
+                            .annotate(email=Lower("user__email"))
+                            .order_by("user__email")
+                        )
+                    elif season_slug == "fall":
+                        pickup_team_members = (
+                            TeamMember.objects.filter(
+                                Q(
+                                    Q(
+                                        Q(team__league__season__slug="spring")
+                                        & Q(team__league__year=year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="summer")
+                                        & Q(team__league__year=year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="fall")
+                                        & Q(team__league__year=year)
+                                    )
+                                )
+                            )
+                            .values()
+                            .annotate(email=Lower("user__email"))
+                            .order_by("user__email")
+                        )
+                    elif season_slug == "late-fall":
                         # do not include late fall since there is only one division
-                        pickup_team_members = TeamMember.objects.filter(Q(Q(Q(team__league__season__slug='summer') & Q(team__league__year=year)) |
-                            Q(Q(team__league__season__slug='fall') & Q(team__league__year=year)))).values().annotate(email=Lower('user__email')).order_by('user__email')
+                        pickup_team_members = (
+                            TeamMember.objects.filter(
+                                Q(
+                                    Q(
+                                        Q(team__league__season__slug="summer")
+                                        & Q(team__league__year=year)
+                                    )
+                                    | Q(
+                                        Q(team__league__season__slug="fall")
+                                        & Q(team__league__year=year)
+                                    )
+                                )
+                            )
+                            .values()
+                            .annotate(email=Lower("user__email"))
+                            .order_by("user__email")
+                        )
 
-                    pickup_email_addresses = list(set([ptm['email'] for ptm in pickup_team_members]))
+                    pickup_email_addresses = list(
+                        set([ptm["email"] for ptm in pickup_team_members])
+                    )
 
-                    pickup_group_address = '{}{}-pickups@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                    pickup_group_name = '{} {} Pickups'.format(season.name, year)
+                    pickup_group_address = (
+                        "{}{}-pickups@lists.annarborultimate.org".format(
+                            season.slug, year[-2:]
+                        )
+                    )
+                    pickup_group_name = "{} {} Pickups".format(season.name, year)
                     pickup_group_id = api.prepare_group_for_sync(
                         group_name=pickup_group_name,
                         group_email_address=pickup_group_address,
-                        force=force)
+                        force=force,
+                    )
 
                     pickup_target_count = len(pickup_email_addresses)
                     pickup_success_count = 0
@@ -224,95 +385,115 @@ class Command(BaseCommand):
                         pickup_success_count += add_to_group(
                             group_email_address=pickup_group_address,
                             group_id=pickup_group_id,
-                            email_address=pickup_email_address)
+                            email_address=pickup_email_address,
+                        )
 
                     if pickup_success_count == pickup_target_count:
-                        self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                        self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(pickup_success_count, pickup_target_count, pickup_group_address)))
+                        self.stdout.write(self.style.SUCCESS("SUCCESS"))
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                "Added {} of {} email addresses to {}".format(
+                                    pickup_success_count,
+                                    pickup_target_count,
+                                    pickup_group_address,
+                                )
+                            )
+                        )
                     else:
-                        self.stdout.write(self.style.ERROR('HMMM...'))
-                        self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(pickup_success_count, pickup_target_count, pickup_group_address)))
+                        self.stdout.write(self.style.ERROR("HMMM..."))
+                        self.stdout.write(
+                            self.style.ERROR(
+                                "Added {} of {} email addresses to {}".format(
+                                    pickup_success_count,
+                                    pickup_target_count,
+                                    pickup_group_address,
+                                )
+                            )
+                        )
 
                 else:
-                    self.stdout.write(self.style.MIGRATE_HEADING('Syncing season list for {} {}:'.format(season_slug, year[-2:])))
+                    self.stdout.write(
+                        self.style.MIGRATE_HEADING(
+                            "Syncing season list for {} {}:".format(
+                                season_slug, year[-2:]
+                            )
+                        )
+                    )
 
-                    return
-                    # ALL
+                    # # ALL
 
-                    all_group_address = '{}{}@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                    all_group_name = '{} {}'.format(season.name, year)
-                    all_group_id = api.prepare_group_for_sync(
-                        group_name=all_group_name,
-                        group_email_address=all_group_address,
-                        force=force)
+                    # all_group_address = '{}{}@lists.annarborultimate.org'.format(season.slug, year[-2:])
+                    # all_group_name = '{} {}'.format(season.name, year)
+                    # all_group_id = api.prepare_group_for_sync(
+                    #     group_name=all_group_name,
+                    #     group_email_address=all_group_address,
+                    #     force=force)
 
-                    all_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year)
-                    all_target_count = all_team_members.count()
-                    all_success_count = 0
-                    for team_member in all_team_members:
-                        all_success_count += add_to_group(
-                            group_email_address=all_group_address,
-                            group_id=all_group_id,
-                            email_address=team_member.user.email)
+                    # all_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year)
+                    # all_target_count = all_team_members.count()
+                    # all_success_count = 0
+                    # for team_member in all_team_members:
+                    #     all_success_count += add_to_group(
+                    #         group_email_address=all_group_address,
+                    #         group_id=all_group_id,
+                    #         email_address=team_member.user.email)
 
-                    # MEN
+                    # # MEN
 
-                    men_group_address = '{}{}-men@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                    men_group_name = '{} {} Men'.format(season.name, year)
-                    men_group_id = api.prepare_group_for_sync(
-                        group_name=men_group_name,
-                        group_email_address=men_group_address,
-                        force=force)
+                    # men_group_address = '{}{}-men@lists.annarborultimate.org'.format(season.slug, year[-2:])
+                    # men_group_name = '{} {} Men'.format(season.name, year)
+                    # men_group_id = api.prepare_group_for_sync(
+                    #     group_name=men_group_name,
+                    #     group_email_address=men_group_address,
+                    #     force=force)
 
-                    men_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='M')
-                    men_target_count = men_team_members.count()
-                    men_success_count = 0
-                    for team_member in men_team_members:
-                        men_success_count += add_to_group(
-                            group_email_address=men_group_address,
-                            group_id=men_group_id,
-                            email_address=team_member.user.email)
+                    # men_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='M')
+                    # men_target_count = men_team_members.count()
+                    # men_success_count = 0
+                    # for team_member in men_team_members:
+                    #     men_success_count += add_to_group(
+                    #         group_email_address=men_group_address,
+                    #         group_id=men_group_id,
+                    #         email_address=team_member.user.email)
 
-                    # WOMEN
+                    # # WOMEN
 
-                    women_group_address = '{}{}-women@lists.annarborultimate.org'.format(season.slug, year[-2:])
-                    women_group_name = '{} {} Women'.format(season.name, year)
-                    women_group_id = api.prepare_group_for_sync(
-                        group_name=women_group_name,
-                        group_email_address=women_group_address,
-                        force=force)
+                    # women_group_address = '{}{}-women@lists.annarborultimate.org'.format(season.slug, year[-2:])
+                    # women_group_name = '{} {} Women'.format(season.name, year)
+                    # women_group_id = api.prepare_group_for_sync(
+                    #     group_name=women_group_name,
+                    #     group_email_address=women_group_address,
+                    #     force=force)
 
-                    women_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='F')
-                    women_target_count = women_team_members.count()
-                    women_success_count = 0
-                    for team_member in women_team_members:
-                        women_success_count += add_to_group(
-                            group_email_address=women_group_address,
-                            group_id=women_group_id,
-                            email_address=team_member.user.email)
+                    # women_team_members = TeamMember.objects.filter(team__league__season__slug=season.slug, team__league__year=year, user__profile__gender__iexact='F')
+                    # women_target_count = women_team_members.count()
+                    # women_success_count = 0
+                    # for team_member in women_team_members:
+                    #     women_success_count += add_to_group(
+                    #         group_email_address=women_group_address,
+                    #         group_id=women_group_id,
+                    #         email_address=team_member.user.email)
 
+                    # if all_success_count == all_team_members.count():
+                    #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
+                    #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
+                    # else:
+                    #     self.stdout.write(self.style.ERROR('HMMM...'))
+                    #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
 
-                    if all_success_count == all_team_members.count():
-                        self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                        self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
-                    else:
-                        self.stdout.write(self.style.ERROR('HMMM...'))
-                        self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(all_success_count, all_target_count, all_group_address)))
+                    # if men_success_count == men_team_members.count():
+                    #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
+                    #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
+                    # else:
+                    #     self.stdout.write(self.style.ERROR('HMMM...'))
+                    #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
 
-                    if men_success_count == men_team_members.count():
-                        self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                        self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
-                    else:
-                        self.stdout.write(self.style.ERROR('HMMM...'))
-                        self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(men_success_count, men_target_count, men_group_address)))
-
-                    if women_success_count == women_team_members.count():
-                        self.stdout.write(self.style.SUCCESS('SUCCESS'))
-                        self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
-                    else:
-                        self.stdout.write(self.style.ERROR('HMMM...'))
-                        self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
+                    # if women_success_count == women_team_members.count():
+                    #     self.stdout.write(self.style.SUCCESS('SUCCESS'))
+                    #     self.stdout.write(self.style.SUCCESS('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
+                    # else:
+                    #     self.stdout.write(self.style.ERROR('HMMM...'))
+                    #     self.stdout.write(self.style.ERROR('Added {} of {} email addresses to {}'.format(women_success_count, women_target_count, women_group_address)))
 
             except Season.DoesNotExist:
-                self.stdout.write(self.style.ERROR('No season found with that slug'))
-
+                self.stdout.write(self.style.ERROR("No season found with that slug"))

--- a/src/ultimate/leagues/management/commands/import_email_group.py
+++ b/src/ultimate/leagues/management/commands/import_email_group.py
@@ -6,6 +6,22 @@ from django.db.models.functions import Lower
 from ultimate.utils.email_groups import add_to_group
 
 
+# Which seasons feed each season's pickup list, as (season_slug, year_offset)
+# pairs. year_offset is relative to the target year: 0 = the target year, -1 =
+# the previous year. A pickup list is the target season plus the two seasons
+# leading into it, so a recent player can be pulled in to fill a roster.
+#
+# late-fall is the exception: it is one division, so it pulls from summer and
+# fall of the same year but is deliberately NOT included in any list itself.
+PICKUP_SEASON_WINDOWS = {
+    "winter": [("fall", -1), ("late-fall", -1), ("winter", 0)],
+    "spring": [("late-fall", -1), ("winter", 0), ("spring", 0)],
+    "summer": [("winter", 0), ("spring", 0), ("summer", 0)],
+    "fall": [("spring", 0), ("summer", 0), ("fall", 0)],
+    "late-fall": [("summer", 0), ("fall", 0)],
+}
+
+
 class Command(BaseCommand):
     help = "Add members to an email group from an email address, file, or team id"
 
@@ -206,6 +222,33 @@ class Command(BaseCommand):
         except League.DoesNotExist:
             self.stdout.write(self.style.ERROR("No league division found with that id"))
 
+    def _pickup_emails(self, TeamMember, season_slug, year):
+        """Return the set of lowercased member emails for a season's pickup list.
+
+        Builds the query from PICKUP_SEASON_WINDOWS: one (slug, year) clause per
+        contributing season, OR'd together.
+        """
+        year = int(year)
+        window = PICKUP_SEASON_WINDOWS.get(season_slug, [])
+
+        season_filter = Q()
+        for slug, year_offset in window:
+            season_filter |= Q(
+                team__league__season__slug=slug,
+                team__league__year=str(year + year_offset),
+            )
+
+        if not window:
+            return set()
+
+        team_members = (
+            TeamMember.objects.filter(season_filter)
+            .values()
+            .annotate(email=Lower("user__email"))
+        )
+
+        return {team_member["email"] for team_member in team_members}
+
     def _handle_season(self, season_slug, year, pickup, force):
         from ultimate.leagues.models import Season, TeamMember
 
@@ -223,120 +266,9 @@ class Command(BaseCommand):
                     )
                 )
 
-                pickup_team_members = []
-                previous_year = str(int(year) - 1)
-
-                if season_slug == "winter":
-                    pickup_team_members = (
-                        TeamMember.objects.filter(
-                            Q(
-                                Q(
-                                    Q(team__league__season__slug="fall")
-                                    & Q(team__league__year=previous_year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="late-fall")
-                                    & Q(team__league__year=previous_year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="winter")
-                                    & Q(team__league__year=year)
-                                )
-                            )
-                        )
-                        .values()
-                        .annotate(email=Lower("user__email"))
-                        .order_by("user__email")
-                    )
-                elif season_slug == "spring":
-                    pickup_team_members = (
-                        TeamMember.objects.filter(
-                            Q(
-                                Q(
-                                    Q(team__league__season__slug="late-fall")
-                                    & Q(team__league__year=previous_year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="winter")
-                                    & Q(team__league__year=year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="spring")
-                                    & Q(team__league__year=year)
-                                )
-                            )
-                        )
-                        .values()
-                        .annotate(email=Lower("user__email"))
-                        .order_by("user__email")
-                    )
-                elif season_slug == "summer":
-                    pickup_team_members = (
-                        TeamMember.objects.filter(
-                            Q(
-                                Q(
-                                    Q(team__league__season__slug="winter")
-                                    & Q(team__league__year=year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="spring")
-                                    & Q(team__league__year=year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="summer")
-                                    & Q(team__league__year=year)
-                                )
-                            )
-                        )
-                        .values()
-                        .annotate(email=Lower("user__email"))
-                        .order_by("user__email")
-                    )
-                elif season_slug == "fall":
-                    pickup_team_members = (
-                        TeamMember.objects.filter(
-                            Q(
-                                Q(
-                                    Q(team__league__season__slug="spring")
-                                    & Q(team__league__year=year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="summer")
-                                    & Q(team__league__year=year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="fall")
-                                    & Q(team__league__year=year)
-                                )
-                            )
-                        )
-                        .values()
-                        .annotate(email=Lower("user__email"))
-                        .order_by("user__email")
-                    )
-                elif season_slug == "late-fall":
-                    # do not include late fall since there is only one division
-                    pickup_team_members = (
-                        TeamMember.objects.filter(
-                            Q(
-                                Q(
-                                    Q(team__league__season__slug="summer")
-                                    & Q(team__league__year=year)
-                                )
-                                | Q(
-                                    Q(team__league__season__slug="fall")
-                                    & Q(team__league__year=year)
-                                )
-                            )
-                        )
-                        .values()
-                        .annotate(email=Lower("user__email"))
-                        .order_by("user__email")
-                    )
-
-                pickup_email_addresses = {
-                    ptm["email"] for ptm in pickup_team_members
-                }
+                pickup_email_addresses = self._pickup_emails(
+                    TeamMember, season_slug, year
+                )
 
                 pickup_group_address = (
                     "{}{}-pickups@lists.annarborultimate.org".format(

--- a/src/ultimate/leagues/management/commands/import_email_group.py
+++ b/src/ultimate/leagues/management/commands/import_email_group.py
@@ -335,9 +335,9 @@ class Command(BaseCommand):
                             .order_by("user__email")
                         )
 
-                    pickup_email_addresses = list(
-                        set([ptm["email"] for ptm in pickup_team_members])
-                    )
+                    pickup_email_addresses = {
+                        ptm["email"] for ptm in pickup_team_members
+                    }
 
                     pickup_group_address = (
                         "{}{}-pickups@lists.annarborultimate.org".format(
@@ -351,37 +351,13 @@ class Command(BaseCommand):
                         force=force,
                     )
 
-                    pickup_target_count = len(pickup_email_addresses)
-                    pickup_success_count = 0
-                    for pickup_email_address in pickup_email_addresses:
-                        pickup_success_count += add_to_group(
-                            group_email_address=pickup_group_address,
-                            group_id=pickup_group_id,
-                            email_address=pickup_email_address,
-                        )
+                    pickup_result = api.sync_group_members(
+                        pickup_email_addresses,
+                        group_id=pickup_group_id,
+                        group_email_address=pickup_group_address,
+                    )
 
-                    if pickup_success_count == pickup_target_count:
-                        self.stdout.write(self.style.SUCCESS("SUCCESS"))
-                        self.stdout.write(
-                            self.style.SUCCESS(
-                                "Added {} of {} email addresses to {}".format(
-                                    pickup_success_count,
-                                    pickup_target_count,
-                                    pickup_group_address,
-                                )
-                            )
-                        )
-                    else:
-                        self.stdout.write(self.style.ERROR("HMMM..."))
-                        self.stdout.write(
-                            self.style.ERROR(
-                                "Added {} of {} email addresses to {}".format(
-                                    pickup_success_count,
-                                    pickup_target_count,
-                                    pickup_group_address,
-                                )
-                            )
-                        )
+                    self._report_sync_result(pickup_result, pickup_group_address)
 
                 else:
                     self.stdout.write(

--- a/src/ultimate/leagues/models.py
+++ b/src/ultimate/leagues/models.py
@@ -256,7 +256,7 @@ class League(models.Model):
     state = models.CharField(
         max_length=32,
         choices=LEAGUE_STATE_CHOICES,
-        help_text="state of league, changes whether registration is open or league is visible",
+        help_text="state of league, controls visibility and whether registration is open",
     )
 
     image_cover = models.ImageField(
@@ -1046,7 +1046,6 @@ class Registrations(models.Model):
             and not self.paypal_complete
             and not self.payment_complete
         ):
-
             return False
 
         if self.refunded:
@@ -1064,7 +1063,6 @@ class Registrations(models.Model):
             and not self.paypal_complete
             and not self.payment_complete
         ):
-
             return False
 
         if not self.refunded:
@@ -1357,7 +1355,6 @@ class Team(models.Model):
 
         games = self.game_set.all()
         for game in games:
-
             team_reports = game.gamereport_set.filter(team=self)
             opponent_reports = game.gamereport_set.exclude(team=self)
             points_for = float(0)
@@ -1405,7 +1402,6 @@ class Team(models.Model):
                 or (team_result == 1 and opponent_result == 0)
                 or (opponent_result == 1 and team_result == 0)
             ):
-
                 team_record["wins"] += 1
 
             elif (
@@ -1413,7 +1409,6 @@ class Team(models.Model):
                 or (team_result == 2 and opponent_result == 0)
                 or (opponent_result == 2 and team_result == 0)
             ):
-
                 team_record["losses"] += 1
 
             elif (
@@ -1421,7 +1416,6 @@ class Team(models.Model):
                 or (team_result == 3 and opponent_result == 0)
                 or (opponent_result == 3 and team_result == 0)
             ):
-
                 team_record["ties"] += 1
 
             elif (
@@ -1429,11 +1423,9 @@ class Team(models.Model):
                 and team_result != 0
                 and opponent_result != 0
             ):
-
                 team_record["conflicts"] += 1
 
             else:
-
                 team_record["blanks"] += 1
 
             if report_count > 1:

--- a/src/ultimate/leagues/models.py
+++ b/src/ultimate/leagues/models.py
@@ -13,7 +13,6 @@ from django.template.defaultfilters import slugify
 from django.utils import timezone
 
 from ultimate.utils.email_groups import (
-    add_to_group,
     generate_email_list_address,
     generate_email_list_name,
 )
@@ -788,30 +787,24 @@ class League(models.Model):
         self.division_email = group_address
         self.division_email_group_id = group_id
 
-        success_count = 0
-
         if Team.objects.filter(league=self).exists():
-            for team_member in TeamMember.objects.filter(team__league=self).order_by(
-                "user__email"
-            ):
-                success_count += add_to_group(
-                    group_email_address=group_address,
-                    group_id=group_id,
-                    email_address=team_member.user.email,
-                )
+            desired_emails = [
+                team_member.user.email
+                for team_member in TeamMember.objects.filter(team__league=self)
+            ]
         else:
-            for registration in sorted(
-                self.get_complete_registrations(), key=lambda r: r.user.email
-            ):
-                success_count += add_to_group(
-                    group_email_address=group_address,
-                    group_id=group_id,
-                    email_address=registration.user.email,
-                )
+            desired_emails = [
+                registration.user.email
+                for registration in self.get_complete_registrations()
+            ]
+
+        result = api.sync_group_members(
+            desired_emails, group_id=group_id, group_email_address=group_address
+        )
 
         self.save()
 
-        return success_count, group_address
+        return result, group_address
 
     def sync_division_captains_email_group(self, force=False):
         group_address = generate_email_list_address(self, suffix="captains")
@@ -830,20 +823,20 @@ class League(models.Model):
         self.division_captains_email = group_address
         self.division_captains_email_group_id = group_id
 
-        success_count = 0
-
-        for team_member in TeamMember.objects.filter(
-            team__league=self, captain=True
-        ).order_by("user__last_name"):
-            success_count += add_to_group(
-                group_email_address=group_address,
-                group_id=group_id,
-                email_address=team_member.user.email,
+        desired_emails = [
+            team_member.user.email
+            for team_member in TeamMember.objects.filter(
+                team__league=self, captain=True
             )
+        ]
+
+        result = api.sync_group_members(
+            desired_emails, group_id=group_id, group_email_address=group_address
+        )
 
         self.save()
 
-        return success_count, group_address
+        return result, group_address
 
 
 class LeagueFields(models.Model):
@@ -1463,19 +1456,17 @@ class Team(models.Model):
         self.email = group_address
         self.group_id = group_id
 
-        success_count = 0
-        for team_member in self.teammember_set.all().order_by(
-            "user__last_name", "user__first_name"
-        ):
-            success_count += add_to_group(
-                group_email_address=group_address,
-                group_id=group_id,
-                email_address=team_member.user.email,
-            )
+        desired_emails = [
+            team_member.user.email for team_member in self.teammember_set.all()
+        ]
+
+        result = api.sync_group_members(
+            desired_emails, group_id=group_id, group_email_address=group_address
+        )
 
         self.save()
 
-        return success_count, group_address
+        return result, group_address
 
 
 class TeamMember(models.Model):

--- a/src/ultimate/leagues/tests/factories.py
+++ b/src/ultimate/leagues/tests/factories.py
@@ -1,0 +1,82 @@
+"""Minimal object factories for the leagues test suite.
+
+These build just enough of the object graph (User -> Season -> League ->
+Team -> TeamMember) to exercise the email-group sync paths, filling required
+model fields with sane defaults so individual tests only specify what they
+care about.
+"""
+
+from datetime import date, datetime
+
+from django.contrib.auth import get_user_model
+
+from ultimate.leagues.models import League, Season, Team, TeamMember
+
+User = get_user_model()
+
+
+def make_user(email, first_name="Test", last_name="User"):
+    return User.objects.create_user(
+        email=email, first_name=first_name, last_name=last_name
+    )
+
+
+def make_season(slug, name=None, order=0):
+    # Season.save() is overridden without *args/**kwargs, so objects.create()
+    # (which passes force_insert=) fails; build and save the instance directly.
+    season = Season(slug=slug, name=name or slug.replace("-", " ").title(), order=order)
+    season.save()
+    return season
+
+
+def make_league(season, year, **overrides):
+    """Create a League with all required fields defaulted.
+
+    Only season and year matter for the email-group tests; everything else is
+    boilerplate the model requires to save.
+    """
+    dt = datetime(year, 1, 1, 12, 0, 0)
+    defaults = dict(
+        season=season,
+        year=year,
+        night="sunday",
+        night_slug="sunday",
+        gender=League.LEAGUE_GENDER_COREC,
+        level=League.LEAGUE_LEVEL_RECREATIONAL,
+        type=League.LEAGUE_TYPE_LEAGUE,
+        summary_info="",
+        detailed_info="",
+        times="6:00-8:00pm",
+        reg_start_date=dt,
+        price_increase_start_date=dt,
+        group_lock_start_date=dt,
+        waitlist_start_date=dt,
+        league_start_date=date(year, 1, 1),
+        league_end_date=date(year, 3, 1),
+        max_players=100,
+        baggage=2,
+        paypal_cost=50,
+        check_cost_increase=5,
+        late_cost_increase=5,
+        mail_check_address="",
+        state=League.LEAGUE_STATE_CLOSED,
+    )
+    defaults.update(overrides)
+    # League.save() is also overridden without *args/**kwargs (see make_season).
+    league = League(**defaults)
+    league.save()
+    return league
+
+
+def make_team(league, name="Team"):
+    return Team.objects.create(league=league, name=name)
+
+
+def make_team_member(team, user, captain=False):
+    return TeamMember.objects.create(team=team, user=user, captain=captain)
+
+
+def add_player(team, email, captain=False, first_name="Test", last_name="User"):
+    """Convenience: create a user and attach them to a team in one call."""
+    user = make_user(email, first_name=first_name, last_name=last_name)
+    return make_team_member(team, user, captain=captain)

--- a/src/ultimate/leagues/tests/test_command.py
+++ b/src/ultimate/leagues/tests/test_command.py
@@ -1,0 +1,141 @@
+"""Tests for the import_email_group management command.
+
+Covers up-front argument validation and end-to-end dispatch for the team,
+league, and pickup sync modes. The Google API is replaced with a fake that
+records the desired-email sets it is asked to sync and returns canned
+GroupSyncResults, so these exercise the command + model wiring without
+network or credentials.
+"""
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from django.utils.six import StringIO
+
+from ultimate.utils import google_api
+from ultimate.utils.google_api import GroupSyncResult
+from ultimate.leagues.tests import factories as f
+
+
+class FakeApi(object):
+    """Records sync calls; returns a fully-successful result by default."""
+
+    calls = []
+
+    def __init__(self):
+        pass
+
+    def prepare_group_for_sync(self, group_name, group_id=None,
+                               group_email_address=None, force=False):
+        return group_id or "gid-for-{}".format(group_email_address)
+
+    def sync_group_members(self, desired_emails, group_id=None,
+                           group_email_address=None):
+        desired = {e.lower() for e in desired_emails if e}
+        FakeApi.calls.append(
+            {"group": group_email_address, "desired": desired}
+        )
+        return GroupSyncResult(
+            target=len(desired),
+            added=sorted(desired),
+            removed=[],
+            failed_add=[],
+            failed_remove=[],
+        )
+
+
+def patch_api(testcase):
+    orig = google_api.GoogleAppsApi
+    google_api.GoogleAppsApi = FakeApi
+    FakeApi.calls = []
+    testcase.addCleanup(lambda: setattr(google_api, "GoogleAppsApi", orig))
+
+
+class ArgValidationTest(TestCase):
+    def _run(self, *args):
+        call_command("import_email_group", *args, stdout=StringIO())
+
+    def test_email_without_group_address_errors(self):
+        with self.assertRaises(CommandError):
+            self._run("-e", "a@x.com")
+
+    def test_file_without_group_address_errors(self):
+        with self.assertRaises(CommandError):
+            self._run("-f", "/tmp/emails.txt")
+
+    def test_season_without_year_errors(self):
+        with self.assertRaises(CommandError):
+            self._run("-s", "spring")
+
+    def test_year_without_season_errors(self):
+        with self.assertRaises(CommandError):
+            self._run("-y", "2026")
+
+    def test_non_numeric_year_errors(self):
+        with self.assertRaises(CommandError):
+            self._run("-s", "spring", "-y", "notayear")
+
+
+class TeamSyncCommandTest(TestCase):
+    def setUp(self):
+        patch_api(self)
+        self.season = f.make_season("spring")
+        self.league = f.make_league(self.season, 2026)
+        self.team = f.make_team(self.league)
+        f.add_player(self.team, "alice@x.com")
+        f.add_player(self.team, "bob@x.com")
+
+    def test_team_sync_passes_member_emails(self):
+        out = StringIO()
+        call_command("import_email_group", "-t", str(self.team.id), stdout=out)
+
+        self.assertEqual(len(FakeApi.calls), 1)
+        self.assertEqual(
+            FakeApi.calls[0]["desired"], {"alice@x.com", "bob@x.com"}
+        )
+        self.assertIn("SUCCESS", out.getvalue())
+
+    def test_missing_team_reports_error(self):
+        out = StringIO()
+        call_command("import_email_group", "-t", "99999", stdout=out)
+
+        self.assertEqual(FakeApi.calls, [])
+        self.assertIn("No team found", out.getvalue())
+
+
+class PickupSyncCommandTest(TestCase):
+    def setUp(self):
+        patch_api(self)
+        self.seasons = {
+            slug: f.make_season(slug)
+            for slug in ["winter", "spring", "summer", "fall", "late-fall"]
+        }
+
+    def _add(self, season_slug, year, email):
+        team = f.make_team(f.make_league(self.seasons[season_slug], year))
+        f.add_player(team, email)
+
+    def test_pickup_sync_uses_season_window(self):
+        self._add("winter", 2026, "winter@x.com")
+        self._add("spring", 2026, "spring@x.com")
+        self._add("summer", 2026, "summer@x.com")
+        self._add("fall", 2026, "fall@x.com")  # out of window for summer
+
+        out = StringIO()
+        call_command(
+            "import_email_group", "-s", "summer", "-y", "2026", "-p", stdout=out
+        )
+
+        self.assertEqual(len(FakeApi.calls), 1)
+        call = FakeApi.calls[0]
+        self.assertEqual(
+            call["desired"], {"winter@x.com", "spring@x.com", "summer@x.com"}
+        )
+        self.assertIn("summer26-pickups@lists.annarborultimate.org", call["group"])
+
+    def test_season_sync_without_pickup_is_not_implemented(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                "import_email_group", "-s", "summer", "-y", "2026",
+                stdout=StringIO(),
+            )

--- a/src/ultimate/leagues/tests/test_google_api.py
+++ b/src/ultimate/leagues/tests/test_google_api.py
@@ -1,0 +1,273 @@
+"""Tests for the diff-based group sync in GoogleAppsApi.
+
+These exercise the new core -- list (with paging), diff, batched add/remove,
+and the 409/404 "already in the desired state" handling -- against a fake
+Directory service so no network or credentials are needed.
+"""
+
+from googleapiclient.errors import HttpError
+from django.test import TestCase
+
+from ultimate.utils import google_api
+from ultimate.utils.google_api import API_BATCH_SIZE, GoogleAppsApi
+
+
+class _Resp(object):
+    """Minimal stand-in for an httplib2 response on an HttpError."""
+
+    def __init__(self, status):
+        self.status = status
+        self.reason = "test"
+
+
+def http_error(status):
+    return HttpError(_Resp(status), b"{}", uri="http://test")
+
+
+class FakeWriteRequest(object):
+    """An unexecuted insert/delete request; carries the email it targets."""
+
+    def __init__(self, kind, email):
+        self.kind = kind
+        self.email = email
+
+
+class FakeListRequest(object):
+    def __init__(self, service):
+        self.service = service
+
+    def execute(self, http=None, num_retries=0):
+        if self.service.list_error is not None:
+            raise self.service.list_error
+        # Return configured pages in order; default to a single empty page.
+        if self.service.pages:
+            return self.service.pages.pop(0)
+        return {}
+
+
+class FakeMembers(object):
+    def __init__(self, service):
+        self.service = service
+
+    def list(self, groupKey=None, pageToken=None):
+        return FakeListRequest(self.service)
+
+    def insert(self, groupKey=None, body=None):
+        return FakeWriteRequest("insert", body["email"])
+
+    def delete(self, groupKey=None, memberKey=None):
+        return FakeWriteRequest("delete", memberKey)
+
+
+class FakeBatch(object):
+    def __init__(self, service, callback):
+        self.service = service
+        self.callback = callback
+        self.items = []
+
+    def add(self, request, request_id=None):
+        self.items.append((request_id, request))
+
+    def execute(self, http=None):
+        if self.service.batch_error is not None:
+            raise self.service.batch_error
+        for request_id, request in self.items:
+            outcome = self.service.outcomes.get(request.email)
+            if outcome is None:
+                self.callback(request_id, {"ok": True}, None)
+            else:
+                self.callback(request_id, None, outcome)
+
+
+class FakeService(object):
+    """Configurable fake of a built Directory API service.
+
+    pages    -- list of members().list() response dicts, returned in order
+    outcomes -- email -> HttpError to raise for that email's batch op
+                (absent email == success)
+    """
+
+    def __init__(self, pages=None, outcomes=None):
+        self.pages = list(pages) if pages else []
+        self.outcomes = outcomes or {}
+        self.list_error = None
+        self.batch_error = None
+        self.batches = []
+        self._members = FakeMembers(self)
+
+    def members(self):
+        return self._members
+
+    def new_batch_http_request(self, callback=None):
+        batch = FakeBatch(self, callback)
+        self.batches.append(batch)
+        return batch
+
+
+def members_page(emails, next_token=None):
+    page = {"members": [{"email": e} for e in emails]}
+    if next_token:
+        page["nextPageToken"] = next_token
+    return page
+
+
+class SyncGroupMembersTest(TestCase):
+    def setUp(self):
+        self.api = GoogleAppsApi()  # http=None under test settings
+
+    def _patch_service(self, service):
+        # Both list_group_members and sync_group_members build their own
+        # service; return the same fake from every build() call.
+        self._build_patch = _PatchBuild(service)
+        self._build_patch.start()
+        self.addCleanup(self._build_patch.stop)
+
+    def test_diff_adds_missing_and_removes_stale(self):
+        service = FakeService(pages=[members_page(["a@x.com", "b@x.com"])])
+        self._patch_service(service)
+
+        result = self.api.sync_group_members(
+            ["b@x.com", "c@x.com"], group_id="gid"
+        )
+
+        self.assertEqual(result.target, 2)
+        self.assertEqual(result.added, ["c@x.com"])
+        self.assertEqual(result.removed, ["a@x.com"])
+        self.assertEqual(result.failed_add, [])
+        self.assertEqual(result.failed_remove, [])
+
+    def test_no_change_makes_no_writes(self):
+        service = FakeService(pages=[members_page(["a@x.com", "b@x.com"])])
+        self._patch_service(service)
+
+        result = self.api.sync_group_members(
+            ["a@x.com", "b@x.com"], group_id="gid"
+        )
+
+        self.assertEqual(result.added, [])
+        self.assertEqual(result.removed, [])
+        # A no-op sync should not even open a batch request.
+        self.assertEqual([b for b in service.batches if b.items], [])
+
+    def test_email_case_is_normalized(self):
+        service = FakeService(pages=[members_page(["a@x.com"])])
+        self._patch_service(service)
+
+        result = self.api.sync_group_members(["A@X.com"], group_id="gid")
+
+        # "A@X.com" lower-cases to the existing "a@x.com": nothing to do.
+        self.assertEqual(result.added, [])
+        self.assertEqual(result.removed, [])
+        self.assertEqual(result.target, 1)
+
+    def test_409_on_add_counts_as_success(self):
+        service = FakeService(
+            pages=[members_page([])], outcomes={"dup@x.com": http_error(409)}
+        )
+        self._patch_service(service)
+
+        result = self.api.sync_group_members(["dup@x.com"], group_id="gid")
+
+        self.assertEqual(result.added, ["dup@x.com"])
+        self.assertEqual(result.failed_add, [])
+
+    def test_404_on_remove_counts_as_success(self):
+        service = FakeService(
+            pages=[members_page(["gone@x.com"])],
+            outcomes={"gone@x.com": http_error(404)},
+        )
+        self._patch_service(service)
+
+        result = self.api.sync_group_members([], group_id="gid")
+
+        self.assertEqual(result.removed, ["gone@x.com"])
+        self.assertEqual(result.failed_remove, [])
+
+    def test_genuine_error_is_reported_as_failed(self):
+        service = FakeService(
+            pages=[members_page([])], outcomes={"bad@x.com": http_error(500)}
+        )
+        self._patch_service(service)
+
+        result = self.api.sync_group_members(["bad@x.com"], group_id="gid")
+
+        self.assertEqual(result.added, [])
+        self.assertEqual(result.failed_add, ["bad@x.com"])
+
+    def test_unresolved_group_reports_all_desired_as_failed_add(self):
+        service = FakeService(pages=[members_page([])])
+        self._patch_service(service)
+
+        # No group_id and no resolvable address -> nothing can be synced.
+        result = self.api.sync_group_members(["a@x.com"], group_id=None)
+
+        self.assertEqual(result.added, [])
+        self.assertEqual(sorted(result.failed_add), ["a@x.com"])
+
+    def test_adds_are_chunked_into_batches(self):
+        service = FakeService(pages=[members_page([])])
+        self._patch_service(service)
+
+        desired = ["u{}@x.com".format(i) for i in range(API_BATCH_SIZE + 10)]
+        result = self.api.sync_group_members(desired, group_id="gid")
+
+        self.assertEqual(len(result.added), API_BATCH_SIZE + 10)
+        # API_BATCH_SIZE + 10 adds should span two batches of <= API_BATCH_SIZE.
+        add_batches = [b for b in service.batches if b.items]
+        self.assertEqual(len(add_batches), 2)
+        self.assertTrue(all(len(b.items) <= API_BATCH_SIZE for b in add_batches))
+
+    def test_whole_batch_failure_marks_all_failed(self):
+        service = FakeService(pages=[members_page([])])
+        service.batch_error = RuntimeError("network down")
+        self._patch_service(service)
+
+        result = self.api.sync_group_members(
+            ["a@x.com", "b@x.com"], group_id="gid"
+        )
+
+        self.assertEqual(result.added, [])
+        self.assertEqual(sorted(result.failed_add), ["a@x.com", "b@x.com"])
+
+
+class ListGroupMembersTest(TestCase):
+    def setUp(self):
+        self.api = GoogleAppsApi()
+
+    def test_pages_through_all_members(self):
+        service = FakeService(
+            pages=[
+                members_page(["a@x.com", "b@x.com"], next_token="t2"),
+                members_page(["c@x.com"]),
+            ]
+        )
+        patch = _PatchBuild(service)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+        emails = self.api.list_group_members(group_id="gid")
+
+        self.assertEqual(emails, {"a@x.com", "b@x.com", "c@x.com"})
+
+    def test_returns_empty_set_without_group(self):
+        service = FakeService(pages=[members_page([])])
+        patch = _PatchBuild(service)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+        self.assertEqual(self.api.list_group_members(group_id=None), set())
+
+
+class _PatchBuild(object):
+    """Patch google_api.build to return a fixed fake service."""
+
+    def __init__(self, service):
+        self.service = service
+        self._orig = None
+
+    def start(self):
+        self._orig = google_api.build
+        google_api.build = lambda *args, **kwargs: self.service
+
+    def stop(self):
+        google_api.build = self._orig

--- a/src/ultimate/leagues/tests/test_pickup_query.py
+++ b/src/ultimate/leagues/tests/test_pickup_query.py
@@ -1,0 +1,109 @@
+"""DB-backed tests for the table-driven pickup season-window query.
+
+The pickup list for a season is built from PICKUP_SEASON_WINDOWS: the target
+season plus the seasons leading into it. These tests stand up real rows for
+several seasons/years and assert _pickup_emails pulls exactly the right people
+-- the behavior the old hand-written Q-block chain used to produce.
+"""
+
+from django.test import TestCase
+
+from ultimate.leagues.management.commands.import_email_group import (
+    Command,
+    PICKUP_SEASON_WINDOWS,
+)
+from ultimate.leagues.models import TeamMember
+from ultimate.leagues.tests import factories as f
+
+
+class PickupQueryTest(TestCase):
+    def setUp(self):
+        self.command = Command()
+        # One season row per slug, reused across years via make_league(year=).
+        self.seasons = {
+            slug: f.make_season(slug)
+            for slug in ["winter", "spring", "summer", "fall", "late-fall"]
+        }
+
+    def _add_member(self, season_slug, year, email):
+        league = f.make_league(self.seasons[season_slug], year)
+        team = f.make_team(league)
+        return f.add_player(team, email)
+
+    def _pickup(self, season_slug, year):
+        return self.command._pickup_emails(TeamMember, season_slug, str(year))
+
+    def test_summer_pulls_winter_spring_summer_same_year(self):
+        self._add_member("winter", 2026, "winter@x.com")
+        self._add_member("spring", 2026, "spring@x.com")
+        self._add_member("summer", 2026, "summer@x.com")
+        # Out of window: fall is after summer; spring of a different year.
+        self._add_member("fall", 2026, "fall@x.com")
+        self._add_member("spring", 2025, "spring-prev@x.com")
+
+        emails = self._pickup("summer", 2026)
+
+        self.assertEqual(
+            emails, {"winter@x.com", "spring@x.com", "summer@x.com"}
+        )
+
+    def test_winter_pulls_prior_year_fall_and_late_fall(self):
+        # winter's window is fall(-1), late-fall(-1), winter(0).
+        self._add_member("fall", 2025, "fall25@x.com")
+        self._add_member("late-fall", 2025, "latefall25@x.com")
+        self._add_member("winter", 2026, "winter26@x.com")
+        # Out of window: this year's fall, last year's winter.
+        self._add_member("fall", 2026, "fall26@x.com")
+        self._add_member("winter", 2025, "winter25@x.com")
+
+        emails = self._pickup("winter", 2026)
+
+        self.assertEqual(
+            emails, {"fall25@x.com", "latefall25@x.com", "winter26@x.com"}
+        )
+
+    def test_spring_pulls_prior_late_fall_and_this_winter_spring(self):
+        self._add_member("late-fall", 2025, "latefall25@x.com")
+        self._add_member("winter", 2026, "winter26@x.com")
+        self._add_member("spring", 2026, "spring26@x.com")
+
+        emails = self._pickup("spring", 2026)
+
+        self.assertEqual(
+            emails,
+            {"latefall25@x.com", "winter26@x.com", "spring26@x.com"},
+        )
+
+    def test_late_fall_pulls_summer_and_fall_but_not_itself(self):
+        self._add_member("summer", 2026, "summer@x.com")
+        self._add_member("fall", 2026, "fall@x.com")
+        # A late-fall member of the same year must NOT be included.
+        self._add_member("late-fall", 2026, "latefall@x.com")
+
+        emails = self._pickup("late-fall", 2026)
+
+        self.assertEqual(emails, {"summer@x.com", "fall@x.com"})
+        self.assertNotIn("latefall@x.com", emails)
+
+    def test_deduplicates_player_in_multiple_window_seasons(self):
+        # The same user plays in two contributing seasons -> appears once.
+        user = f.make_user("repeat@x.com")
+        winter_team = f.make_team(f.make_league(self.seasons["winter"], 2026))
+        spring_team = f.make_team(f.make_league(self.seasons["spring"], 2026))
+        f.make_team_member(winter_team, user)
+        f.make_team_member(spring_team, user)
+
+        emails = self._pickup("summer", 2026)
+
+        self.assertEqual(emails, {"repeat@x.com"})
+
+    def test_unknown_season_returns_empty(self):
+        self._add_member("summer", 2026, "summer@x.com")
+        self.assertEqual(self._pickup("offseason", 2026), set())
+
+    def test_window_table_covers_all_real_seasons(self):
+        # Guard against a season slug silently missing from the table.
+        self.assertEqual(
+            set(PICKUP_SEASON_WINDOWS),
+            {"winter", "spring", "summer", "fall", "late-fall"},
+        )

--- a/src/ultimate/settings/test.py
+++ b/src/ultimate/settings/test.py
@@ -1,0 +1,32 @@
+"""Settings for running the test suite.
+
+Builds on the dev settings but swaps in an in-memory SQLite database so the
+suite runs anywhere without a live MySQL server, and blanks out the Google
+Apps credentials file so GoogleAppsApi() can be constructed without real
+service-account keys (tests mock the API surface).
+
+Run with:
+    APP_RUNMODE=dev DJANGO_SETTINGS_MODULE=ultimate.settings.test \
+        python manage.py test
+"""
+
+from .dev import *  # noqa: F401,F403
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+# No real service-account keyfile in test/CI; GoogleAppsApi.__init__ skips
+# credential loading when this is falsy, leaving self.http = None.
+GOOGLE_APPS_API_CREDENTIALS_FILE = ""
+
+# Fast, deterministic password hashing for tests.
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
+# Quiet the a2u.email_groups debug chatter during test runs.
+import logging  # noqa: E402
+
+logging.disable(logging.CRITICAL)

--- a/src/ultimate/utils/email_groups.py
+++ b/src/ultimate/utils/email_groups.py
@@ -11,9 +11,7 @@ def add_to_group(
     if email_address:
         time.sleep(2)
         if api.add_group_member(
-            email_address,
-            group_id=group_id,
-            group_email_address=group_email_address,
+            email_address, group_id=group_id, group_email_address=group_email_address
         ):
             success_count = success_count + 1
 

--- a/src/ultimate/utils/email_groups.py
+++ b/src/ultimate/utils/email_groups.py
@@ -1,4 +1,3 @@
-import time
 from ultimate.utils.google_api import GoogleAppsApi
 
 
@@ -9,7 +8,6 @@ def add_to_group(
     success_count = 0
 
     if email_address:
-        time.sleep(2)
         if api.add_group_member(
             email_address, group_id=group_id, group_email_address=group_email_address
         ):

--- a/src/ultimate/utils/google_api.py
+++ b/src/ultimate/utils/google_api.py
@@ -16,6 +16,11 @@ logger = logging.getLogger("a2u.email_groups")
 # calls that were sprinkled between every member operation.
 API_NUM_RETRIES = 5
 
+# Maximum number of sub-requests to send in a single batch HTTP request. The
+# Directory API allows up to 1000, but Google recommends keeping batches at or
+# below 50 to stay clear of per-batch limits.
+API_BATCH_SIZE = 50
+
 
 class GoogleAppsApi:
     http = None
@@ -257,6 +262,57 @@ class GoogleAppsApi:
                 break
 
         return emails
+
+    def _execute_batch(self, service, operations, ok_statuses=()):
+        """Run member operations in batched HTTP requests.
+
+        ``operations`` is a list of (email_address, request) tuples, where each
+        request is an unexecuted googleapiclient request (e.g. a members insert
+        or delete). Requests are sent in chunks of API_BATCH_SIZE.
+
+        An HTTP error whose status is listed in ``ok_statuses`` is treated as
+        success (e.g. 409 "already a member" on an add, 404 "not a member" on a
+        delete). Returns (succeeded_emails, failed_emails) as two lists, where
+        failed_emails holds the addresses whose operation genuinely errored.
+        """
+        succeeded = []
+        failed = []
+
+        for start in range(0, len(operations), API_BATCH_SIZE):
+            chunk = operations[start : start + API_BATCH_SIZE]
+
+            # Map the synthetic request id back to the email it belongs to so
+            # the callback can record per-address success/failure.
+            id_to_email = {}
+
+            def callback(request_id, response, exception, id_to_email=id_to_email):
+                email = id_to_email.get(request_id)
+                if exception is None:
+                    succeeded.append(email)
+                elif (
+                    isinstance(exception, HttpError)
+                    and exception.resp.status in ok_statuses
+                ):
+                    succeeded.append(email)
+                else:
+                    logger.debug("  Failure for {}: {}".format(email, exception))
+                    failed.append(email)
+
+            batch = service.new_batch_http_request(callback=callback)
+            for email_address, request in chunk:
+                request_id = str(len(id_to_email) + 1)
+                id_to_email[request_id] = email_address
+                batch.add(request, request_id=request_id)
+
+            try:
+                batch.execute(http=self.http)
+            except Exception as error:
+                # A whole-batch transport failure: none of this chunk's
+                # callbacks fired, so count every address in it as failed.
+                logger.debug("  Batch request failed: {}".format(error))
+                failed.extend(email for email, _ in chunk)
+
+        return succeeded, failed
 
     def add_group_member(
         self, email_address, group_id=None, group_email_address=None, group_name=None

--- a/src/ultimate/utils/google_api.py
+++ b/src/ultimate/utils/google_api.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from datetime import datetime
 import dateutil.parser
 import httplib2
@@ -20,6 +21,17 @@ API_NUM_RETRIES = 5
 # Directory API allows up to 1000, but Google recommends keeping batches at or
 # below 50 to stay clear of per-batch limits.
 API_BATCH_SIZE = 50
+
+
+# Result of a diff-based group membership sync.
+#   target          - number of addresses the group should contain
+#   added/removed   - addresses successfully added/removed this run
+#   failed_add      - addresses that should have been added but errored
+#   failed_remove   - addresses that should have been removed but errored
+GroupSyncResult = namedtuple(
+    "GroupSyncResult",
+    ["target", "added", "removed", "failed_add", "failed_remove"],
+)
 
 
 class GoogleAppsApi:
@@ -313,6 +325,81 @@ class GoogleAppsApi:
                 failed.extend(email for email, _ in chunk)
 
         return succeeded, failed
+
+    def sync_group_members(
+        self, desired_emails, group_id=None, group_email_address=None
+    ):
+        """Make a group's membership match ``desired_emails`` with minimal calls.
+
+        Lists the current members, diffs against the desired set, and only adds
+        the addresses that are missing and removes the ones that should no
+        longer be there -- rather than emptying the group and re-adding
+        everyone. Adds and removes are sent in batched HTTP requests.
+
+        ``desired_emails`` is any iterable of email addresses (case is
+        normalized). Returns a GroupSyncResult.
+        """
+        service = build("admin", "directory_v1", http=self.http, cache_discovery=False)
+
+        if group_email_address and not group_id:
+            group_id = self._resolve_group_id(service, group_email_address)
+
+        desired = {email.lower() for email in desired_emails if email}
+        target = len(desired)
+
+        if not group_id:
+            logger.debug("  Group could not be resolved for sync")
+            return GroupSyncResult(
+                target=target,
+                added=[],
+                removed=[],
+                failed_add=sorted(desired),
+                failed_remove=[],
+            )
+
+        current = self.list_group_members(group_id=group_id)
+
+        to_add = sorted(desired - current)
+        to_remove = sorted(current - desired)
+
+        logger.debug(
+            "  Sync {}: {} desired, {} current, {} to add, {} to remove".format(
+                group_email_address or group_id,
+                target,
+                len(current),
+                len(to_add),
+                len(to_remove),
+            )
+        )
+
+        add_ops = [
+            (
+                email,
+                service.members().insert(
+                    groupKey=group_id, body={"email": email, "role": "MEMBER"}
+                ),
+            )
+            for email in to_add
+        ]
+        # 409: address is already a member -> already in the desired state.
+        added, failed_add = self._execute_batch(service, add_ops, ok_statuses=(409,))
+
+        remove_ops = [
+            (email, service.members().delete(groupKey=group_id, memberKey=email))
+            for email in to_remove
+        ]
+        # 404: address is not a member -> already in the desired state.
+        removed, failed_remove = self._execute_batch(
+            service, remove_ops, ok_statuses=(404,)
+        )
+
+        return GroupSyncResult(
+            target=target,
+            added=added,
+            removed=removed,
+            failed_add=failed_add,
+            failed_remove=failed_remove,
+        )
 
     def add_group_member(
         self, email_address, group_id=None, group_email_address=None, group_name=None

--- a/src/ultimate/utils/google_api.py
+++ b/src/ultimate/utils/google_api.py
@@ -57,15 +57,13 @@ class GoogleAppsApi:
     ):
         logger.debug('Preparing group "{}" for sync...'.format(group_name))
 
+        # force deliberately wipes the group (delete + recreate) for a clean
+        # slate. Without force we leave the existing members in place: the
+        # diff-based sync_group_members reconciles them, so there is no longer
+        # any need to remove everyone up front and re-add them.
         if force:
             self.delete_group(
                 group_id=group_id, group_email_address=group_email_address
-            )
-        else:
-            self.remove_all_group_members(
-                group_id=group_id,
-                group_email_address=group_email_address,
-                group_name=group_name,
             )
 
         return self.get_or_create_group(

--- a/src/ultimate/utils/google_api.py
+++ b/src/ultimate/utils/google_api.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import time
 import dateutil.parser
 import httplib2
 import logging
@@ -7,9 +6,15 @@ import logging
 from django.conf import settings
 
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from oauth2client.service_account import ServiceAccountCredentials
 
 logger = logging.getLogger("a2u.email_groups")
+
+# Number of times the client library retries a throttled/5xx request with
+# exponential backoff before giving up. Replaces the old fixed time.sleep()
+# calls that were sprinkled between every member operation.
+API_NUM_RETRIES = 5
 
 
 class GoogleAppsApi:
@@ -184,8 +189,7 @@ class GoogleAppsApi:
                         member_id = member.get("id", None)
                         service.members().delete(
                             groupKey=group_id, memberKey=member_id
-                        ).execute(http=self.http)
-                        time.sleep(2)
+                        ).execute(http=self.http, num_retries=API_NUM_RETRIES)
             except Exception:
                 logger.debug("    Group could not be found")
                 return False
@@ -215,11 +219,16 @@ class GoogleAppsApi:
                 response = (
                     service.members()
                     .insert(groupKey=group_id, body=body)
-                    .execute(http=self.http)
+                    .execute(http=self.http, num_retries=API_NUM_RETRIES)
                 )
                 logger.debug("  Success!")
-            except:
-                logger.debug("  Failure!")
+            except HttpError as error:
+                # A 409 means the address is already a member, which for a sync
+                # is a success, not a failure -- treat it as already present.
+                if error.resp.status == 409:
+                    logger.debug("  Already a member!")
+                    return True
+                logger.debug("  Failure! {}".format(error))
                 return False
 
         return response

--- a/src/ultimate/utils/google_api.py
+++ b/src/ultimate/utils/google_api.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import time
 import dateutil.parser
 import httplib2
 import logging
@@ -130,9 +131,11 @@ class GoogleAppsApi:
             try:
                 members_response = service.members().list(groupKey=group_id).execute(http=self.http)
                 if members_response and members_response.get('members'):
+                    logger.debug('  Removing {} members from {}...'.format(members_response.get('members'), group_email_address))
                     for member in members_response.get('members'):
                         member_id = member.get('id', None)
                         service.members().delete(groupKey=group_id, memberKey=member_id).execute(http=self.http)
+                        time.sleep(2)
             except Exception as e:
                 logger.debug('    Group could not be found')
                 return False

--- a/src/ultimate/utils/google_api.py
+++ b/src/ultimate/utils/google_api.py
@@ -5,194 +5,262 @@ import httplib2
 import logging
 
 from django.conf import settings
-from django.utils.timezone import make_aware
 
 from googleapiclient.discovery import build
 from oauth2client.service_account import ServiceAccountCredentials
 
-logger = logging.getLogger('a2u.email_groups')
+logger = logging.getLogger("a2u.email_groups")
 
 
 class GoogleAppsApi:
     http = None
 
     def __init__(self):
-        credentials_file = getattr(settings, 'GOOGLE_APPS_API_CREDENTIALS_FILE', False)
-        scopes = getattr(settings, 'GOOGLE_APPS_API_SCOPES', False)
-        account = getattr(settings, 'GOOGLE_APPS_API_ACCOUNT', False)
+        credentials_file = getattr(settings, "GOOGLE_APPS_API_CREDENTIALS_FILE", False)
+        scopes = getattr(settings, "GOOGLE_APPS_API_SCOPES", False)
+        account = getattr(settings, "GOOGLE_APPS_API_ACCOUNT", False)
 
         if credentials_file and scopes and account:
             credentials = ServiceAccountCredentials.from_json_keyfile_name(
-                credentials_file, scopes=scopes)
+                credentials_file, scopes=scopes
+            )
 
-            credentials._kwargs['sub'] = account
+            credentials._kwargs["sub"] = account
 
             self.http = httplib2.Http()
             self.http = credentials.authorize(self.http)
 
-    def prepare_group_for_sync(self, group_name, group_id=None, group_email_address=None, force=False):
+    def prepare_group_for_sync(
+        self, group_name, group_id=None, group_email_address=None, force=False
+    ):
         logger.debug('Preparing group "{}" for sync...'.format(group_name))
 
         if force:
-            self.delete_group(group_id=group_id, group_email_address=group_email_address)
+            self.delete_group(
+                group_id=group_id, group_email_address=group_email_address
+            )
         else:
             self.remove_all_group_members(
                 group_id=group_id,
                 group_email_address=group_email_address,
-                group_name=group_name)
+                group_name=group_name,
+            )
 
         return self.get_or_create_group(
-            group_email_address=group_email_address, group_name=group_name)
+            group_email_address=group_email_address, group_name=group_name
+        )
 
     # TODO need paging for when you have over 200 groups
-    def get_or_create_group(self, group_email_address, group_name=''):
-        logger.debug('  Getting or creating group {}...'.format(group_email_address))
+    def get_or_create_group(self, group_email_address, group_name=""):
+        logger.debug("  Getting or creating group {}...".format(group_email_address))
 
-        service = build('admin', 'directory_v1', http=self.http, cache_discovery=False)
+        service = build("admin", "directory_v1", http=self.http, cache_discovery=False)
 
         groups_response = None
         target_group = None
 
         try:
-            logger.debug('    Looking for existing group...')
-            groups_response = service.groups().list(customer='my_customer', domain='lists.annarborultimate.org', query='email={}'.format(group_email_address)).execute(http=self.http)
-        except Exception as e:
+            logger.debug("    Looking for existing group...")
+            groups_response = (
+                service.groups()
+                .list(
+                    customer="my_customer",
+                    domain="lists.annarborultimate.org",
+                    query="email={}".format(group_email_address),
+                )
+                .execute(http=self.http)
+            )
+        except Exception:
             return None
 
-        if groups_response and groups_response.get('groups'):
-            for group in groups_response.get('groups'):
-                if group.get('email') == group_email_address:
-                    logger.debug('    Group found!')
+        if groups_response and groups_response.get("groups"):
+            for group in groups_response.get("groups"):
+                if group.get("email") == group_email_address:
+                    logger.debug("    Group found!")
                     target_group = group
 
         # couldn't find group, create it
         if not target_group:
-            logger.debug('    Group not found...creating {}...'.format(group_email_address))
+            logger.debug(
+                "    Group not found...creating {}...".format(group_email_address)
+            )
 
-            body = { 'email': group_email_address, }
+            body = {
+                "email": group_email_address,
+            }
             if group_name:
-                body.update({ 'name': group_name, })
+                body.update(
+                    {
+                        "name": group_name,
+                    }
+                )
 
             try:
-                target_group = service.groups().insert(body=body).execute(http=self.http)
-                logger.debug('    Success!')
-            except Exception as e:
-                logger.debug('    Failure!')
+                target_group = (
+                    service.groups().insert(body=body).execute(http=self.http)
+                )
+                logger.debug("    Success!")
+            except Exception:
+                logger.debug("    Failure!")
                 return None
 
-        group_id = target_group.get('id', None)
+        group_id = target_group.get("id", None)
 
         return group_id
 
     def delete_group(self, group_id=None, group_email_address=None):
-        logger.debug('  Deleting existing group...')
+        logger.debug("  Deleting existing group...")
 
-        service = build('admin', 'directory_v1', http=self.http, cache_discovery=False)
+        service = build("admin", "directory_v1", http=self.http, cache_discovery=False)
 
         if group_email_address and not group_id:
             try:
-                groups_response = service.groups().list(customer='my_customer', domain='lists.annarborultimate.org', query='email={}'.format(group_email_address)).execute(http=self.http)
+                groups_response = (
+                    service.groups()
+                    .list(
+                        customer="my_customer",
+                        domain="lists.annarborultimate.org",
+                        query="email={}".format(group_email_address),
+                    )
+                    .execute(http=self.http)
+                )
 
-                if groups_response and groups_response.get('groups'):
-                    for group in groups_response.get('groups'):
-                        if group.get('email') == group_email_address:
-                            group_id = group.get('id', None)
-            except Exception as e:
+                if groups_response and groups_response.get("groups"):
+                    for group in groups_response.get("groups"):
+                        if group.get("email") == group_email_address:
+                            group_id = group.get("id", None)
+            except Exception:
                 return False
 
         if group_id:
             try:
                 service.groups().delete(groupKey=group_id).execute(http=self.http)
-                logger.debug('    Success!')
-            except Exception as e:
-                logger.debug('    Failure!')
+                logger.debug("    Success!")
+            except Exception:
+                logger.debug("    Failure!")
                 return False
 
         return True
 
-    def remove_all_group_members(self, group_id=None, group_email_address=None, group_name=None):
-        logger.debug('  Removing all members from {}...'.format(group_email_address))
+    def remove_all_group_members(
+        self, group_id=None, group_email_address=None, group_name=None
+    ):
+        logger.debug("  Removing all members from {}...".format(group_email_address))
 
-        service = build('admin', 'directory_v1', http=self.http, cache_discovery=False)
+        service = build("admin", "directory_v1", http=self.http, cache_discovery=False)
 
         if group_email_address and not group_id:
             try:
-                groups_response = service.groups().list(customer='my_customer', domain='lists.annarborultimate.org', query='email={}'.format(group_email_address)).execute(http=self.http)
+                groups_response = (
+                    service.groups()
+                    .list(
+                        customer="my_customer",
+                        domain="lists.annarborultimate.org",
+                        query="email={}".format(group_email_address),
+                    )
+                    .execute(http=self.http)
+                )
 
-                if groups_response and groups_response.get('groups'):
-                    for group in groups_response.get('groups'):
-                        if group.get('email') == group_email_address:
-                            group_id = group.get('id', None)
-            except Exception as e:
-                logger.debug('    Group could not be found')
+                if groups_response and groups_response.get("groups"):
+                    for group in groups_response.get("groups"):
+                        if group.get("email") == group_email_address:
+                            group_id = group.get("id", None)
+            except Exception:
+                logger.debug("    Group could not be found")
                 return False
 
         if group_id:
             try:
-                members_response = service.members().list(groupKey=group_id).execute(http=self.http)
-                if members_response and members_response.get('members'):
-                    logger.debug('  Removing {} members from {}...'.format(members_response.get('members'), group_email_address))
-                    for member in members_response.get('members'):
-                        member_id = member.get('id', None)
-                        service.members().delete(groupKey=group_id, memberKey=member_id).execute(http=self.http)
+                members_response = (
+                    service.members().list(groupKey=group_id).execute(http=self.http)
+                )
+                if members_response and members_response.get("members"):
+                    logger.debug(
+                        "  Removing {} members from {}...".format(
+                            members_response.get("members"), group_email_address
+                        )
+                    )
+                    for member in members_response.get("members"):
+                        member_id = member.get("id", None)
+                        service.members().delete(
+                            groupKey=group_id, memberKey=member_id
+                        ).execute(http=self.http)
                         time.sleep(2)
-            except Exception as e:
-                logger.debug('    Group could not be found')
+            except Exception:
+                logger.debug("    Group could not be found")
                 return False
 
-        logger.debug('    Done')
+        logger.debug("    Done")
 
-    def add_group_member(self, email_address, group_id=None, group_email_address=None, group_name=None):
-        logger.debug('Adding {} to {}...'.format(email_address, group_email_address or 'group'))
+    def add_group_member(
+        self, email_address, group_id=None, group_email_address=None, group_name=None
+    ):
+        logger.debug(
+            "Adding {} to {}...".format(email_address, group_email_address or "group")
+        )
 
-        service = build('admin', 'directory_v1', http=self.http, cache_discovery=False)
+        service = build("admin", "directory_v1", http=self.http, cache_discovery=False)
 
-        body = {
-            'email': email_address,
-            'role': 'MEMBER'
-        }
+        body = {"email": email_address, "role": "MEMBER"}
         response = False
 
         # look for group
         if not group_id and group_email_address:
             group_id = self.get_or_create_group(
-                group_email_address=group_email_address, group_name=group_name)
+                group_email_address=group_email_address, group_name=group_name
+            )
 
         if group_id:
             try:
-                response = service.members().insert(groupKey=group_id, body=body).execute(http=self.http)
-                logger.debug('  Success!')
+                response = (
+                    service.members()
+                    .insert(groupKey=group_id, body=body)
+                    .execute(http=self.http)
+                )
+                logger.debug("  Success!")
             except:
-                logger.debug('  Failure!')
+                logger.debug("  Failure!")
                 return False
 
         return response
 
     def get_calendar_events(self, calendar_id, since, until):
-        service = build(serviceName='calendar', version='v3', http=self.http, cache_discovery=False)
+        service = build(
+            serviceName="calendar", version="v3", http=self.http, cache_discovery=False
+        )
 
-        since = (datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) - since).isoformat('T') + 'Z'
-        until = (datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) + until).isoformat('T') + 'Z'
+        since = (
+            datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) - since
+        ).isoformat("T") + "Z"
+        until = (
+            datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) + until
+        ).isoformat("T") + "Z"
 
         try:
-            events_response = service.events().list(
-                calendarId=calendar_id,
-                orderBy='startTime',
-                singleEvents=True,
-                timeMin=since,
-                timeMax=until,
-            ).execute(http=self.http)
-        except Exception as e:
+            events_response = (
+                service.events()
+                .list(
+                    calendarId=calendar_id,
+                    orderBy="startTime",
+                    singleEvents=True,
+                    timeMin=since,
+                    timeMax=until,
+                )
+                .execute(http=self.http)
+            )
+        except Exception:
             return None
 
         events = []
-        for event in events_response['items']:
-            events.append({
-                'summary': event.get('summary'),
-                'start': dateutil.parser.parse(event['start']['dateTime']),
-                'end': event['end']['dateTime'],
-                'location': event.get('location'),
-                'description': event.get('description'),
-            })
+        for event in events_response["items"]:
+            events.append(
+                {
+                    "summary": event.get("summary"),
+                    "start": dateutil.parser.parse(event["start"]["dateTime"]),
+                    "end": event["end"]["dateTime"],
+                    "location": event.get("location"),
+                    "description": event.get("description"),
+                }
+            )
 
         return events

--- a/src/ultimate/utils/google_api.py
+++ b/src/ultimate/utils/google_api.py
@@ -196,6 +196,68 @@ class GoogleAppsApi:
 
         logger.debug("    Done")
 
+    def _resolve_group_id(self, service, group_email_address):
+        """Look up a group's id by its email address. Returns None if not found."""
+        try:
+            groups_response = (
+                service.groups()
+                .list(
+                    customer="my_customer",
+                    domain="lists.annarborultimate.org",
+                    query="email={}".format(group_email_address),
+                )
+                .execute(http=self.http)
+            )
+        except Exception:
+            return None
+
+        if groups_response and groups_response.get("groups"):
+            for group in groups_response.get("groups"):
+                if group.get("email") == group_email_address:
+                    return group.get("id", None)
+
+        return None
+
+    def list_group_members(self, group_id=None, group_email_address=None):
+        """Return the set of lowercased member email addresses for a group.
+
+        Pages through the full membership (the Directory API returns at most
+        200 members per response) so callers get every member, not just the
+        first page. Returns an empty set if the group can't be resolved.
+        """
+        service = build("admin", "directory_v1", http=self.http, cache_discovery=False)
+
+        if group_email_address and not group_id:
+            group_id = self._resolve_group_id(service, group_email_address)
+
+        emails = set()
+
+        if not group_id:
+            return emails
+
+        page_token = None
+        while True:
+            try:
+                members_response = (
+                    service.members()
+                    .list(groupKey=group_id, pageToken=page_token)
+                    .execute(http=self.http, num_retries=API_NUM_RETRIES)
+                )
+            except Exception:
+                logger.debug("    Members could not be listed")
+                break
+
+            for member in members_response.get("members", []):
+                email = member.get("email")
+                if email:
+                    emails.add(email.lower())
+
+            page_token = members_response.get("nextPageToken")
+            if not page_token:
+                break
+
+        return emails
+
     def add_group_member(
         self, email_address, group_id=None, group_email_address=None, group_name=None
     ):


### PR DESCRIPTION
## Summary

Reworks how the `import_email_group` command syncs members to Google Groups. Previously a sync would find the group, **remove every member one at a time**, then **re-add everyone one at a time** — each call padded with a `time.sleep(2)`. This was slow, hit API rate limits often, and briefly left the group empty mid-sync.

Now the sync **diffs** current vs. desired membership and only applies the deltas, sending adds/removes in **batched HTTP requests** with exponential-backoff retry instead of fixed sleeps. A no-change re-sync is nearly free; a stable group is never emptied.

> **Note on commit range:** this branch was based on `rdonnelly/main`, which was 5 commits ahead of `a2ultimate/main`. Those 5 (markdown upgrade, LeagueAdmin tweaks, an interim "add time delays" rate-limit commit, two formatting commits) are included here. The interim time-delay commit is **superseded** by this PR's backoff change.

## Core changes

1. **Diff instead of remove-all-then-add.** New `GoogleAppsApi.sync_group_members()` lists current members (paged — fixes the old >200 truncation), diffs against the desired set, and only adds missing / removes stale addresses.
2. **Bulk + rate limits.** Adds/removes go through `_execute_batch()` (≤50 per request). The blanket `time.sleep(2)` is replaced by the client's built-in backoff (`execute(num_retries=5)`). A bare `except:` that miscounted 409 "already a member" as a failure is fixed. **Partial failures are reported with the specific addresses** that couldn't be added/removed.

## Cleanups bundled in

- Split the ~400-line `handle()` into per-mode helpers + a shared `_report_sync_result`.
- Replaced the five near-identical season Q-blocks with a `PICKUP_SEASON_WINDOWS` table — **verified to generate byte-identical SQL** to the originals. late-fall still pulls summer+fall and excludes itself.
- Argument validation (`-s`/`-y` required together, numeric year), `options[...]` over `options.get(..., None)`, and deleted the dead commented-out ALL/MEN/WOMEN block (running `-s`/`-y` without `-p` was a silent no-op; now a clear error).

## Tests

Adds 27 tests, runnable anywhere via a sqlite-backed test settings module (no live MySQL or Google credentials):

- `test_google_api` — diff/batch core against a fake Directory service: adds-missing/removes-stale, **no-op sync makes no writes**, case normalization, 409-on-add / 404-on-remove as success, genuine + whole-batch failures reported, list paging, batch chunking.
- `test_pickup_query` — DB-backed checks that each season's pickup window returns the right members, incl. late-fall excluding itself and cross-season dedup.
- `test_command` — arg validation and team/league/pickup dispatch with a fake API.

Verified with **mutation testing**: reverting the diff to the old "add everyone" behavior fails 3 tests; breaking the late-fall window fails its dedicated test.

```
cd src && APP_RUNMODE=dev DJANGO_SETTINGS_MODULE=ultimate.settings.test python manage.py test ultimate
```

## Caveat

The diff/batch logic and pickup query are tested with the Google API faked — the real Directory batch endpoint and live rate-limit backoff aren't exercised (would need credentials). Recommend a single manual dry-run against one real group before relying on it in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)